### PR TITLE
CP-2625 Release w_common 0.1.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: w_common
 description: General utilities for Dart projects.
-version: 0.0.1
+version: 0.0.2
 author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://www.github.com/Workiva/w_common
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: w_common
 description: General utilities for Dart projects.
-version: 0.0.2
+version: 0.1.0
 author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://www.github.com/Workiva/w_common
 


### PR DESCRIPTION
Pulls Included in Release:
- [CP-2741 Add new Func<T> generic typedef](https://github.com/Workiva/w_common/pull/4)
- [cp-2743 : added JsonSerializable + test](https://github.com/Workiva/w_common/pull/5)
- [CP-2777 Add invalidation_mixin](https://github.com/Workiva/w_common/pull/6)
- [REF-1340: Prep for OSS](https://github.com/Workiva/w_common/pull/7)
- [REF-1341 Fix warnings, tidy tests, fix doc comments.](https://github.com/Workiva/w_common/pull/2)
- [REF-1356 Add a dummy smithy file](https://github.com/Workiva/w_common/pull/3)

Requested by: @charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_common/compare/0.0.1...version-bump-w_common-0-0-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_common/compare/0.0.1...0.0.2
