### PR TITLE
REF-1387 Implement manageDisposer()

### DIFF
--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -26,6 +26,10 @@ class DisposableThing extends Object with Disposable {
     manageDisposable(thing);
   }
 
+  void testManageDisposer(Disposer disposer) {
+    manageDisposer(disposer);
+  }
+
   void testManageStreamController(StreamController controller) {
     manageStreamController(controller);
   }
@@ -64,6 +68,23 @@ void main() {
         expect(childThing.isDisposed, isFalse);
         await thing.dispose();
         expect(childThing.isDisposed, isTrue);
+      });
+    });
+
+    group('manageDisposer', () {
+      test(
+          'should call callback and accept null return value'
+          'when parent is disposed', () async {
+        thing.testManageDisposer(expectAsync(() => null, count: 1) as Disposer);
+        await thing.dispose();
+      });
+
+      test(
+          'should call callback and accept Future return value'
+          'when parent is disposed', () async {
+        thing.testManageDisposer(
+            expectAsync(() => new Future(() {}), count: 1) as Disposer);
+        await thing.dispose();
       });
     });
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -20,7 +20,7 @@ import 'package:dart_dev/dart_dev.dart'
 Future main(List<String> args) async {
   // https://github.com/Workiva/dart_dev
 
-  config.analyze.entryPoints = ['lib/', 'lib/src', 'test/unit/', 'tool/'];
+  config.analyze.entryPoints = ['lib/', 'test/unit/', 'tool/'];
 
   config.format
     ..directories = [


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description

It would be nice for Disposable to be able to automagically manage arbitrary objects the way it can manage stream subscriptions and other `Disposable` things.

### Changes

Add a `manageDisposer` method (I'm open to renaming) that will accept a callback that is expected to handle cleanup of one or more objects (usually one, I would imagine).

### Semantic Versioning

> **This library is still pre-1.0.0.**
>
> Patches and minor changes will be released in a patch version, while breaking
> changes can be released in a minor version.

- [x] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Minor**
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API


### Testing/QA

- [x] CI passes

### Code Review

@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf @ref-pp
