### PR TITLE
REF-1399 Fail immediately on null argument

### DIFF
--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -138,23 +138,32 @@ abstract class Disposable implements _Disposable {
   }
 
   /// Automatically dispose another object when this object is disposed.
+  ///
+  /// The parameter may not be `null`.
   @mustCallSuper
   @protected
   void manageDisposable(Disposable disposable) {
+    _throwIfNull(disposable, 'disposable');
     _internalDisposables.add(disposable);
   }
 
   /// Automatically handle arbitrary disposals using a callback.
+  ///
+  /// The parameter may not be `null`.
   @mustCallSuper
   @protected
   void manageDisposer(Disposer disposer) {
+    _throwIfNull(disposer, 'disposer');
     _internalDisposables.add(new _InternalDisposable(disposer));
   }
 
   /// Automatically cancel a stream controller when this object is disposed.
+  ///
+  /// The parameter may not be `null`.
   @mustCallSuper
   @protected
   void manageStreamController(StreamController controller) {
+    _throwIfNull(controller, 'controller');
     _internalDisposables.add(new _InternalDisposable(() {
       if (!controller.hasListener) {
         controller.stream.listen((_) {});
@@ -164,9 +173,12 @@ abstract class Disposable implements _Disposable {
   }
 
   /// Automatically cancel a stream subscription when this object is disposed.
+  ///
+  /// The parameter may not be `null`.
   @mustCallSuper
   @protected
   void manageStreamSubscription(StreamSubscription subscription) {
+    _throwIfNull(subscription, 'subscription');
     _internalDisposables
         .add(new _InternalDisposable(() => subscription.cancel()));
   }
@@ -180,5 +192,11 @@ abstract class Disposable implements _Disposable {
   Null _completeDisposeFuture(List<dynamic> _) {
     _didDispose.complete();
     return null;
+  }
+
+  void _throwIfNull(dynamic subscription, String name) {
+    if (subscription == null) {
+      throw new ArgumentError.notNull(name);
+    }
   }
 }

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -69,6 +69,10 @@ void main() {
         await thing.dispose();
         expect(childThing.isDisposed, isTrue);
       });
+
+      test('should throw if called with a null argument', () {
+        expect(() => thing.testManageDisposable(null), throwsArgumentError);
+      });
     });
 
     group('manageDisposer', () {
@@ -85,6 +89,10 @@ void main() {
         thing.testManageDisposer(
             expectAsync(() => new Future(() {}), count: 1) as Disposer);
         await thing.dispose();
+      });
+
+      test('should throw if called with a null argument', () {
+        expect(() => thing.testManageDisposer(null), throwsArgumentError);
       });
     });
 
@@ -120,6 +128,11 @@ void main() {
         await thing.dispose();
         expect(controller.isClosed, isTrue);
       });
+
+      test('should throw if called with a null argument', () {
+        expect(
+            () => thing.testManageStreamController(null), throwsArgumentError);
+      });
     });
 
     group('manageStreamSubscription', () {
@@ -133,6 +146,11 @@ void main() {
         controller.add(null);
         await subscription.cancel();
         await controller.close();
+      });
+
+      test('should throw if called with a null argument', () {
+        expect(() => thing.testManageStreamSubscription(null),
+            throwsArgumentError);
       });
     });
   });


### PR DESCRIPTION
### Description

Right now we fail if one of the "manage" methods on `Disposable` gets a `null` value. However, we only fail once `dispose()` has been called, so the error is rather confusing.

### Changes

It seems reasonable to me that those methods shouldn't accept `null` arguments because there's no reason for that to ever occur in actual code, and if it did, it's almost certainly a bug in the consumer's code. If we don't deal with the `null` noisily it could lead to tricky memory leaks or other hard-to-find errors.

However, we should fail immediately so that we provide the consumer with an easily-understood stack trace and error message. This PR just makes those methods throw if they get a `null` argument.

### Semantic Versioning

> **This library is still pre-1.0.0.**
>
> Patches and minor changes will be released in a patch version, while breaking
> changes can be released in a minor version.

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Minor**
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API


### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf

### FYI

@dustyholmes-wf 