### PR TITLE
RAP-1455 Add isDisposing and isDisposedOrDisposing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,11 +13,6 @@
 
 ### Semantic Versioning
 
-> **This library is still pre-1.0.0.**
->
-> Patches and minor changes will be released in a patch version, while breaking
-> changes can be released in a minor version.
-
 - [ ] **Patch**
   - [ ] This change does not affect the public API
   - [ ] This change fixes existing incorrect behavior without any additions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,18 +21,23 @@
 - [ ] **Patch**
   - [ ] This change does not affect the public API
   - [ ] This change fixes existing incorrect behavior without any additions
+- [ ] **Minor**
   - [ ] This change adds something to the public API
   - [ ] This change deprecates a part of the public API
-- [ ] **Minor**
+* [ ] Major
   - [ ] This change modifies part of the public API in a backwards-incompatible manner
   - [ ] This change removes part of the public API
-
 
 ### Testing/QA
 
 - [ ] CI passes
 
-
 ### Code Review
 
-@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf
+@dustinlessard-wf
+@evanweible-wf
+@jayudey-wf
+@maxwellpeterson-wf
+@sebastianmalysa-wf
+@trentgrover-wf
+

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -113,6 +113,20 @@ abstract class Disposable implements _Disposable {
   /// Whether this object has been disposed.
   bool get isDisposed => _didDispose.isCompleted;
 
+  /// Whether this object has been disposed or is disposing.
+  ///
+  /// This will become `true` as soon as the [dispose] method is called
+  /// and will remain `true` forever. This is intended as a convenience
+  /// and `object.isDisposedOrDisposing` will always be the same as
+  /// `object.isDisposed || object.isDisposing`.
+  bool get isDisposedOrDisposing => isDisposed || isDisposing;
+
+  /// Whether this object is in the process of being disposed.
+  ///
+  /// This will become `true` as soon as the [dispose] method is called
+  /// and will become `false` once the [didDispose] future completes.
+  bool get isDisposing => _isDisposing;
+
   /// Dispose of the object, cleaning up to prevent memory leaks.
   @override
   Future<Null> dispose() async {
@@ -191,6 +205,7 @@ abstract class Disposable implements _Disposable {
 
   Null _completeDisposeFuture(List<dynamic> _) {
     _didDispose.complete();
+    _isDisposing = false;
     return null;
   }
 

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -40,8 +40,18 @@ class DisposableThing extends Object with Disposable {
 
   @override
   Future<Null> onDispose() {
+    expect(isDisposed, isFalse);
+    expect(isDisposing, isTrue);
+    expect(isDisposedOrDisposing, isTrue);
     wasOnDisposeCalled = true;
-    return new Future(() {});
+    var future = new Future<Null>(() => null);
+    future.then((_) async {
+      await new Future(() {}); // Give it a chance to update state.
+      expect(isDisposed, isTrue);
+      expect(isDisposing, isFalse);
+      expect(isDisposedOrDisposing, isTrue);
+    });
+    return future;
   }
 }
 


### PR DESCRIPTION
### Description

It would be handy for consumers to have two getters available to them:

  * `isDisposing` - we already had this internally. It is useful because once `dispose()` is called all bets are off as far as using stream controllers and other "managed" objects. But right now there's no way for consumers to guard their code to prevent, for example, adding to a closed stream controller.
  * `isDisposedOrDisposing` - this is just a convenient shortcut for `object.isDisposed || object.isDisposing` (shocking, I know). In most cases consumers would want to use this check to guard stream controllers, etc.

### Changes

Add the above getters and make sure they're exercised in the tests.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
- [ ] **Major**
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [x] CI passes


### Code Review

@dustinlessard-wf @evanweible-wf @jayudey-wf @maxwellpeterson-wf @sebastianmalysa-wf @trentgrover-wf

