### PR TITLE
RAP-1500 Extract manage methods into an interface

### DIFF
--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -120,11 +120,15 @@ typedef Future<dynamic> Disposer();
 ///
 /// Below is an example of using the class as a concrete proxy.
 ///
-///      class MyLifecycleThing {
+///      class MyLifecycleThing implements DisposableManager {
 ///        Disposable _disposable = new Disposable();
 ///
 ///        MyLifecycleThing() {
 ///          _disposable.manageStreamSubscription(someStream.listen(() => null));
+///        }
+///
+///        void manageStreamSubscription(StreamSubscription sub) {
+///          _disposable.manageStreamSubscription(sub);
 ///        }
 ///
 ///        // ...

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -127,11 +127,12 @@ typedef Future<dynamic> Disposer();
 ///          _disposable.manageStreamSubscription(someStream.listen(() => null));
 ///        }
 ///
+///        @override
 ///        void manageStreamSubscription(StreamSubscription sub) {
 ///          _disposable.manageStreamSubscription(sub);
 ///        }
 ///
-///        // ...
+///        // ...more methods
 ///
 ///        Future<Null> unload() async {
 ///          await _disposable.dispose();

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -37,13 +37,25 @@ class _InternalDisposable implements _Disposable {
   }
 }
 
+/// An interface to abstract management from actual disposal machinery.
+///
+/// When new management methods are to be added, they should be added
+/// here first, then implemented in [Disposable].
+abstract class DisposableManager {
+  void manageDisposable(Disposable disposable);
+  void manageDisposer(Disposer disposer);
+  void manageStreamController(StreamController controller);
+  void manageStreamSubscription(StreamSubscription subscription);
+}
+
 /// A function that, when called, disposes of one or more objects.
 typedef Future<dynamic> Disposer();
 
 /// Allows the creation of managed objects, including helpers for common patterns.
 ///
-/// There are three ways to consume this class: as a mixin, a base class,
-/// and an interface. All should work fine but the first is the simplest
+/// There are four ways to consume this class: as a mixin, a base class,
+/// an interface, and a concrete class used as a proxy. All should work
+/// fine but the first is the simplest
 /// and most powerful. Using the class as an interface will require
 /// significant effort.
 ///
@@ -102,7 +114,28 @@ typedef Future<dynamic> Disposer();
 ///      myDisposable.didDispose.then((_) {
 ///        // External cleanup
 ///      });
-abstract class Disposable implements _Disposable {
+///
+/// Below is an example of using the class as a concrete proxy.
+///
+///      class MyLifecycleThing {
+///        Disposable _disposable = new Disposable();
+///
+///        MyLifecycleThing() {
+///          _disposable.manageStreamSubscription(someStream.listen(() => null));
+///        }
+///
+///        // ...
+///
+///        Future<Null> unload() async {
+///          await _disposable.dispose();
+///        }
+///      }
+///
+/// In this case, we want `MyLifecycleThing` to have its own lifecycle
+/// without explicit reference to [Disposable]. To do this, we use
+/// composition to include the [Disposable] machinery without changing
+/// the public interface of our class or polluting its lifecycle.
+class Disposable implements _Disposable, DisposableManager {
   Completer<Null> _didDispose = new Completer<Null>();
   bool _isDisposing = false;
   List<_Disposable> _internalDisposables = [];
@@ -155,7 +188,7 @@ abstract class Disposable implements _Disposable {
   ///
   /// The parameter may not be `null`.
   @mustCallSuper
-  @protected
+  @override
   void manageDisposable(Disposable disposable) {
     _throwIfNull(disposable, 'disposable');
     _internalDisposables.add(disposable);
@@ -165,7 +198,7 @@ abstract class Disposable implements _Disposable {
   ///
   /// The parameter may not be `null`.
   @mustCallSuper
-  @protected
+  @override
   void manageDisposer(Disposer disposer) {
     _throwIfNull(disposer, 'disposer');
     _internalDisposables.add(new _InternalDisposable(disposer));
@@ -175,7 +208,7 @@ abstract class Disposable implements _Disposable {
   ///
   /// The parameter may not be `null`.
   @mustCallSuper
-  @protected
+  @override
   void manageStreamController(StreamController controller) {
     _throwIfNull(controller, 'controller');
     _internalDisposables.add(new _InternalDisposable(() {
@@ -190,7 +223,7 @@ abstract class Disposable implements _Disposable {
   ///
   /// The parameter may not be `null`.
   @mustCallSuper
-  @protected
+  @override
   void manageStreamSubscription(StreamSubscription subscription) {
     _throwIfNull(subscription, 'subscription');
     _internalDisposables

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -37,7 +37,10 @@ class _InternalDisposable implements _Disposable {
   }
 }
 
-/// An interface to abstract management from actual disposal machinery.
+/// Managers for disposable members.
+///
+/// This interface allows consumers to exercise more control over how
+/// disposal is implemented for their classes.
 ///
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].


### PR DESCRIPTION
### Description

We want to be able to expose the helpful manage methods without making a class itself "Disposable".

### Changes

Extract manage methods into an interface that we then implement in `Disposable`. Additionally, remove `@protected` from the manage method implementations. We need this for two reasons. First, because they're not technically part of the interface if they're protected, and second, because we want to be able to use `Disposable` as a concrete proxy. Finally, make `Disposable` concrete.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf
@bencampbell-wf 
@aaronstgeorge-wf 

