### PR TITLE
RAP-1503 Implement Cache and ReferenceCache

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A collection of helpful utilities for use in Dart projects. Right now, it
 includes the following:
 
-  * A `Cache` implementation that maintians references to an object instance by
+  * A `Cache` implementation that maintains references to an object instance by
   an identifier. Specializations of this class allow invariants to be
   maintained:
     * `ReferenceCache` maintains a count for each access for a given identifier.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ includes the following:
   * A `Cache` implementation that maintains references to an object instance by
   an identifier. Specializations of this class allow invariants to be
   maintained:
-    * `ReferenceCache` maintains a count for each access for a given identifier.
+    * A `ReferenceCache` maintains a count for each access for a given identifier.
     When the final reference is released, the item is removed from the cache.
   * A `Disposable` interface / mixin to assist with cleaning up streams and
   other data structures that won't necessarily be garbage collected without some
   manual intervention.
   * A simple typedef that can be parameterized to represent a zero-arity
   callback that returns a particular type.
-  * A `InvalidationMixin` mixin used to mark a class as requiring validation.
+  * An `InvalidationMixin` mixin used to mark a class as requiring validation.
   * A `JsonSerializable` interface to indicate that something can be serialized
   to JSON.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A collection of helpful utilities for use in Dart projects. Right now, it
 includes the following:
 
   * A `Cache` implementation that maintains references to an object instance by
-  an identifier. Specializations of this class allow invariants to be
-  maintained:
-    * A `ReferenceCache` maintains a count for each access for a given identifier.
-    When the final reference is released, the item is removed from the cache.
+  an identifier. Specializations of this class allow invariant to be
+  maintained. For instance, the `ReferenceCache` maintains a count of gets
+  and releases. The item is removed from the cache when these counts are equal.
   * A `Disposable` interface / mixin to assist with cleaning up streams and
   other data structures that won't necessarily be garbage collected without some
   manual intervention.

--- a/README.md
+++ b/README.md
@@ -3,13 +3,18 @@
 A collection of helpful utilities for use in Dart projects. Right now, it
 includes the following:
 
-  * `Disposable` interface / mixin to assist with cleaning up streams and other
-  data structures that won't necessarily be garbage collected without some
+  * A `Cache` implementation that maintians references to an object instance by
+  an identifier. Specializations of this class allow invariants to be
+  maintained:
+    * `ReferenceCache` maintains a count for each access for a given identifier.
+    When the final reference is released, the item is removed from the cache.
+  * A `Disposable` interface / mixin to assist with cleaning up streams and
+  other data structures that won't necessarily be garbage collected without some
   manual intervention.
   * A simple typedef that can be parameterized to represent a zero-arity
   callback that returns a particular type.
-  * `InvalidationMixin` mixin used to mark a class as requiring validation.
-  * `JsonSerializable` interface to indicate that something can be serialized
+  * A `InvalidationMixin` mixin used to mark a class as requiring validation.
+  * A `JsonSerializable` interface to indicate that something can be serialized
   to JSON.
 
 We expect this list to grow as we identify small pieces of code that are useful

--- a/lib/cache.dart
+++ b/lib/cache.dart
@@ -1,0 +1,2 @@
+export 'package:w_common/src/cache/cache.dart' show Cache, CacheContext;
+export 'package:w_common/src/cache/reference_cache.dart' show ReferenceCache;

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -1,0 +1,237 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import 'package:w_common/disposable.dart';
+import 'package:w_common/func.dart';
+
+/// Immutable payload that indicates a change in a [Cache].
+class CacheContext<TIdentifier, TValue> {
+  /// Identifies a single instance of a [TValue]
+  final TIdentifier id;
+
+  /// The current value stored in the [Cache] for the attributed [TIdentifier].
+  final TValue value;
+
+  CacheContext(this.id, this.value);
+}
+
+/// Maintians a reference to a given any [TValue] attributed to a [TIdentifier].
+///
+/// References are retained for the lifecycle of the instance of the [Cache],
+/// unless explicitly removed.
+class Cache<TIdentifier, TValue> extends Object with Disposable {
+  Map<TIdentifier, Future<TValue>> _cache = <TIdentifier, Future<TValue>>{};
+  StreamController<CacheContext<TIdentifier, TValue>> _didUpdateController =
+      new StreamController<CacheContext<TIdentifier, TValue>>.broadcast();
+  StreamController<CacheContext<TIdentifier, TValue>> _didRemoveController =
+      new StreamController<CacheContext<TIdentifier, TValue>>.broadcast();
+  Map<TIdentifier, Completer<Null>> _removalCompleters =
+      <TIdentifier, Completer<Null>>{};
+
+  Cache() {
+    [_didRemoveController, _didUpdateController]
+        .forEach(manageStreamController);
+  }
+
+  /// The collection of removals from the [Cache].
+  Stream<CacheContext<TIdentifier, TValue>> get didRemove =>
+      _didRemoveController.stream;
+
+  /// The collection of changes to the [Cache].
+  ///
+  /// Values are emitted when the cached value is changes.
+  Stream<CacheContext<TIdentifier, TValue>> get didUpdate =>
+      _didUpdateController.stream;
+
+  /// Returns a value from the cache for a given [TIdentifier] or adds the
+  /// [TValue] returned by the value factory when the value does not exist in
+  /// the cache.
+  ///
+  /// All calls to [get] await a call to the [onGet] lifecycle method before
+  /// returning the cached value. If the [Cache] does not contain an instance
+  /// for the given [TIdentifier], the given [valueFactory] is called and an
+  /// [CacheContext] event is emitted on the [didUpdate] stream. A call to [get]
+  /// that returns a cached value does not emit this event as the [Cache] has
+  /// not updated.
+  ///
+  /// Calls to [get] are evaluated syncronously and will return the future value
+  /// established by the first call to [get]. This allows calls to get to
+  /// return the same value regardless of completion of asyncronous calls to
+  /// the [onGet] lifecycle methods or [valueFactory].
+  ///
+  /// ```
+  /// var a = cache.get('id', _superLongCall);
+  /// var b = cache.get('id', _superLongCall);
+  /// var c = cache.get('id', _superLongCall);
+  ///
+  /// // All of the values in this list are the same instance returned by the
+  /// // first call to `_superLongCall`.
+  /// var values = Future.wait([a, b, c]);
+  /// ```
+  ///
+  /// If the [Cache] [isDisposedOrDisposing] then a [StateError] is thrown.
+  @mustCallSuper
+  Future<TValue> get(TIdentifier id, Func<TValue> valueFactory) {
+    _throwWhenDisposed('get');
+
+    // Await any pending cached futures
+    if (_cache.containsKey(id)) {
+      return _cache[id].then((TValue value) async {
+        await onGet(id, value);
+        return value;
+      });
+    }
+
+    // Install Future value
+    final Completer<TValue> completer = new Completer<TValue>();
+    _cache[id] = completer.future;
+    final TValue value = valueFactory.call();
+
+    onGet(id, value).then((Null _) {
+      _didUpdateController.add(new CacheContext(id, value));
+      completer.complete(value);
+    });
+
+    return _cache[id];
+  }
+
+  /// Returns a value from the cache for a given [TIdentifier] or adds the
+  /// [TValue] resolved from the [Future] returned by factory when the value
+  /// does not exist in the cache.
+  ///
+  /// All calls to [get] await a call to the [onGet] lifecycle method before
+  /// returning the cached value. If the [Cache] does not contain an instance
+  /// for the given [TIdentifier], the given [valueFactory] is called and an
+  /// [CacheContext] event is emitted on the [didUpdate] stream. A call to [get]
+  /// that returns a cached value does not emit this event as the [Cache] has
+  /// not updated.
+  ///
+  /// Calls to [get] are evaluated syncronously and will return the future value
+  /// established by the first call to [get]. This allows calls to get to
+  /// return the same value regardless of completion of asyncronous calls to
+  /// the [onGet] lifecycle methods or [valueFactory].
+  ///
+  /// ```
+  /// var a = cache.getAsync('id', _superLongAsyncCall);
+  /// var b = cache.getAsync('id', _superLongAsyncCall);
+  /// var c = cache.getAsync('id', _superLongAsyncCall);
+  ///
+  /// // All of the values in this list are the same instance returned by the
+  /// // first call to `_superLongAsyncCall`.
+  /// var values = Future.wait([a, b, c]);
+  /// ```
+  ///
+  /// If the [Cache] [isDisposedOrDisposing] then a [StateError] is thrown.
+  @mustCallSuper
+  Future<TValue> getAsync(TIdentifier id, Func<Future<TValue>> valueFactory) {
+    _throwWhenDisposed('getAsync');
+
+    // Await any pending cached futures
+    if (_cache.containsKey(id)) {
+      return _cache[id].then((TValue value) async {
+        await onGet(id, value);
+        return value;
+      });
+    }
+
+    // Install Future value
+    final Completer<TValue> completer = new Completer<TValue>();
+    _cache[id] = completer.future;
+    valueFactory.call().then((TValue value) async {
+      await onGet(id, value);
+      _didUpdateController.add(new CacheContext(id, value));
+      completer.complete(value);
+    });
+
+    return _cache[id];
+  }
+
+  /// Is the given identifier in the [Cache]?
+  ///
+  /// If the [Cache] [isDisposedOrDisposing] then a [StateError] is thrown.
+  bool isCached(TIdentifier id) {
+    _throwWhenDisposed('determine if id is cached');
+    return _cache.containsKey(id);
+  }
+
+  /// Updates the current value for a given [TIdentifier] with the given
+  /// [TValue].
+  ///
+  /// Putting a value into the [Cache] results in the imeddiate replacement. any
+  /// future call to [get] or [getAsync] will return the given [value]. Any call
+  /// to put will await the completion of the [onPut] lifecycle method before
+  /// returning the given value. A [CacheContext] event is emitted by the
+  /// [didUpdate] stream upon completion of the [put].
+  ///
+  /// If the [Cache] [isDisposedOrDisposing] then a [StateError] is thrown.
+  Future<TValue> put(TIdentifier id, TValue value) {
+    _throwWhenDisposed('put');
+    final Completer<TValue> completer = new Completer<TValue>();
+    _cache[id] = completer.future;
+
+    onPut(id, value).then((Null _) {
+      _didUpdateController.add(new CacheContext(id, value));
+      completer.complete(value);
+    });
+
+    return _cache[id];
+  }
+
+  /// Allows consumers to define behavior that is executed when a [TValue] is
+  /// obtained from the [Cache].
+  @protected
+  Future<Null> onGet(TIdentifier id, TValue value) async {}
+
+  /// Allows consumers to define behavior that is executed when a [TValue] is
+  /// updated in the [Cache].
+  @protected
+  Future<Null> onPut(TIdentifier id, TValue value) async {}
+
+  /// Allows consumers to define behavior that is executed when a [TValue] is
+  /// removed.
+  @protected
+  Future<Null> onRemove(TIdentifier id, TValue value) async {}
+
+  /// Removes the reference to a [TValue] associated with the given
+  /// [TIdentifier].
+  ///
+  /// If a value is currently cached for the given [TIdentifier], the completion
+  /// of the [get] or [put] that inserted the [TIdentifier] into the cache is
+  /// awaited before removal. This ensures that any pending asyncronous calls
+  /// against the cache resovle to a value.
+  ///
+  /// A [CacheContext] value is emitted by the [didUpdate] stream upon
+  /// successfull removal of the given [TIdentifier].
+  ///
+  /// If the [Cache] [isDisposedOrDisposing] then a [StateError] is thrown.
+  @mustCallSuper
+  Future<Null> remove(TIdentifier id) {
+    _throwWhenDisposed('remove');
+
+    if (_cache.containsKey(id)) {
+      return _removalCompleters.putIfAbsent(id, () {
+        final completer = new Completer<Null>();
+
+        _cache[id].then((TValue value) async {
+          await onRemove(id, value);
+          await _cache.remove(id);
+          _removalCompleters.remove(id);
+          _didRemoveController.add(new CacheContext(id, value));
+          _didUpdateController.add(new CacheContext(id, null));
+          completer.complete();
+        });
+
+        return completer;
+      }).future;
+    }
+
+    return new Future.value();
+  }
+
+  void _throwWhenDisposed(String op) {
+    if (isDisposedOrDisposing) {
+      throw new StateError('Cannot $op when Cache is disposed');
+    }
+  }
+}

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -41,11 +41,13 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
         .forEach(manageStreamController);
   }
 
-  /// The stream of events that indicate a removal [Cache].
+  /// A stream of [CacheContext]s that dispatches when an item is removed from
+  /// the cache.
   Stream<CacheContext<TIdentifier, TValue>> get didRemove =>
       _didRemoveController.stream;
 
-  /// The stream of events that indicate a change to a cached [TValue].
+  /// The stream of [CacheContext]s that dispatches when an item is updated in
+  /// the cache.
   Stream<CacheContext<TIdentifier, TValue>> get didUpdate =>
       _didUpdateController.stream;
 

--- a/lib/src/cache/reference_cache.dart
+++ b/lib/src/cache/reference_cache.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 
 import 'package:w_common/src/cache/cache.dart';
 
-/// Maintains the number of references for an instance of an cache value.
+/// Maintains the number of references to an instance of a cache value.
 class ReferenceCache<TIdentifier, TValue> extends Cache<TIdentifier, TValue> {
   Map<TIdentifier, int> _count = {};
 

--- a/lib/src/cache/reference_cache.dart
+++ b/lib/src/cache/reference_cache.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import 'package:w_common/src/cache/cache.dart';
+
+/// Maintains the number of references for an instance of an cache value.
+class ReferenceCache<TIdentifier, TValue> extends Cache<TIdentifier, TValue> {
+  Map<TIdentifier, int> _count = {};
+
+  @override
+  @protected
+  @mustCallSuper
+  Future<Null> onGet(TIdentifier id, TValue value) async {
+    _count[id] = _count.putIfAbsent(id, () => 0) + 1;
+  }
+
+  @override
+  @protected
+  @mustCallSuper
+  Future<Null> onPut(TIdentifier id, TValue value) async {
+    _count[id] = 1;
+  }
+
+  /// A lifecycle method called when the cache releases a count for a given
+  /// [TIdentifier].
+  @protected
+  @mustCallSuper
+  Future<Null> onRelease(TIdentifier id) async {}
+
+  @override
+  @protected
+  @mustCallSuper
+  Future<Null> onRemove(TIdentifier id, TValue value) async {
+    _count.remove(id);
+  }
+
+  /// The number of references maintained for a given [TIdentifier].
+  ///
+  /// If the [ReferenceCache] [isDisposedOrDisposing] then a [StateError] is
+  /// thrown.
+  int referenceCount(TIdentifier id) {
+    _throwIfDisposed('referenceCount');
+    return _count[id] ?? 0;
+  }
+
+  /// Releases a reference for a given [TIdentifier] and removes the
+  /// [TIdentifier] from the [ReferenceCache] when the last reference is
+  /// released.
+  ///
+  /// If the [ReferenceCache] [isDisposedOrDisposing] then a [StateError] is
+  /// thrown.
+  @mustCallSuper
+  Future<Null> release(TIdentifier id) {
+    _throwIfDisposed('release');
+
+    var refs = referenceCount(id);
+
+    if (refs == 0) {
+      return new Future.value();
+    }
+
+    final Completer<Null> completer = new Completer<Null>();
+
+    if (refs == 1) {
+      remove(id).then((Null _) async {
+        await onRelease(id);
+        completer.complete();
+      });
+    } else {
+      onRelease(id).then((Null _) => completer.complete());
+    }
+
+    _count[id] = refs - 1;
+    return completer.future;
+  }
+
+  void _throwIfDisposed(String op) {
+    if (isDisposedOrDisposing) {
+      throw new StateError("Cannot $op with disposed ReferenceCache");
+    }
+  }
+}

--- a/test/unit/browser/generated_browser_tests.dart.temp.html
+++ b/test/unit/browser/generated_browser_tests.dart.temp.html
@@ -1,0 +1,1 @@
+<script type="application/dart" src="generated_browser_tests.dart"></script>

--- a/test/unit/browser/invalidation_mixin_test.dart
+++ b/test/unit/browser/invalidation_mixin_test.dart
@@ -36,7 +36,7 @@ void main() {
         expect(thing.invalid, isTrue);
 
         // ignore: unawaited_futures
-        onValidation.then(expectAsync((ValidationStatus status) {
+        onValidation.then(expectAsync1((ValidationStatus status) {
           expect(status, equals(ValidationStatus.cancelled));
         }, count: 1));
 
@@ -49,12 +49,12 @@ void main() {
         Future onValidation = thing.invalidate();
 
         // ignore: unawaited_futures
-        onValidation.then(expectAsync((ValidationStatus status) {
+        onValidation.then(expectAsync1((ValidationStatus status) {
           expect(status, equals(ValidationStatus.complete));
         }, count: 1));
 
         // ignore: STRONG_MODE_DOWN_CAST_COMPOSITE
-        thing.onValidate.listen(expectAsync((_) {}, count: 1));
+        thing.onValidate.listen(expectAsync1((_) {}, count: 1));
       });
     });
   });

--- a/test/unit/vm/cache/cache_test.dart
+++ b/test/unit/vm/cache/cache_test.dart
@@ -30,7 +30,7 @@ void main() {
 
       test(
           'should return same value when called successively '
-          'syncronously', () async {
+          'synchronously', () async {
         var cachedValues = <Future<Object>>[
           cache.get(notCachedId, () => notCachedValue),
           cache.get(notCachedId, () => new Object())
@@ -99,18 +99,18 @@ void main() {
       });
     });
 
-    group('isCached', () {
+    group('containsKey', () {
       test('should return false when identifier has not been cached', () {
-        expect(cache.isCached(notCachedId), isFalse);
+        expect(cache.containsKey(notCachedId), isFalse);
       });
 
       test('should return true when identifier has been cached', () {
-        expect(cache.isCached(cachedId), isTrue);
+        expect(cache.containsKey(cachedId), isTrue);
       });
 
       test('should return false when identifier has been removed', () async {
         await cache.remove(cachedId);
-        expect(cache.isCached(cachedId), isFalse);
+        expect(cache.containsKey(cachedId), isFalse);
       });
 
       test('should throw when disposed', () async {
@@ -135,7 +135,7 @@ void main() {
         expect(childCache.onPutValue, putValue);
       });
 
-      test('should put syncronously', () {
+      test('should put synchronously', () {
         final getA = cache.getAsync(notCachedId, () async {
           await new Future.delayed(new Duration(milliseconds: 100));
           return notCachedValue;
@@ -170,7 +170,7 @@ void main() {
 
       test(
           'should dispatch one didUpdate event when identifier is removed '
-          'syncronously', () {
+          'synchronously', () {
         cache.didUpdate.listen(expectAsync1((CacheContext context) {
           expect(context.id, cachedId);
           expect(context.value, isNull);
@@ -191,7 +191,7 @@ void main() {
 
       test(
           'should dispatch one didRemove event when identifier is removed '
-          'syncronously', () {
+          'synchronously', () {
         cache.didRemove.listen(expectAsync1((CacheContext context) {
           expect(context.id, cachedId);
           expect(context.value, cachedValue);
@@ -221,7 +221,7 @@ void main() {
         expect(childCache.onRemoveValue, isNull);
       });
 
-      test('should remove after pending get if called syncronously', () {
+      test('should remove after pending get if called synchronously', () {
         cache.get(notCachedId, () => notCachedValue);
         cache.remove(notCachedId).then(expectAsync1((Null _) {
           expect(cacheEvents.ids, [notCachedId, notCachedId]);
@@ -229,7 +229,7 @@ void main() {
         }));
       });
 
-      test('should remove after pending getAsync if called syncronously', () {
+      test('should remove after pending getAsync if called synchronously', () {
         cache.getAsync(notCachedId, () async {
           await new Future.delayed(new Duration(milliseconds: 100));
           return notCachedValue;
@@ -240,7 +240,7 @@ void main() {
         }));
       });
 
-      test('should remove after pending put if called syncronously', () {
+      test('should remove after pending put if called synchronously', () {
         cache.put(putId, putValue);
         cache.remove(putId).then(expectAsync1((Null _) {
           expect(cacheEvents.ids, [putId, putId]);

--- a/test/unit/vm/cache/cache_test.dart
+++ b/test/unit/vm/cache/cache_test.dart
@@ -55,13 +55,13 @@ void main() {
         expect(didCallValueFactory, isTrue);
       });
 
-      test('should not call valueFactory if id is cached', () async {
+      test('should not call valueFactory if identifier is cached', () async {
         var didCallValueFactory = false;
-        await cache.get(notCachedId, () {
+        await cache.get(cachedId, () {
           didCallValueFactory = true;
           return notCachedValue;
         });
-        expect(didCallValueFactory, isTrue);
+        expect(didCallValueFactory, isFalse);
       });
 
       test('should not dispatch didUpdate event on cached get', () async {

--- a/test/unit/vm/cache/cache_test.dart
+++ b/test/unit/vm/cache/cache_test.dart
@@ -1,0 +1,301 @@
+import 'dart:async';
+
+import 'package:test/test.dart';
+
+import 'package:w_common/src/cache/cache.dart';
+
+void main() {
+  group('Cache', () {
+    Cache<String, Object> cache;
+    CacheEvents<String, Object> cacheEvents;
+    final String cachedId = '1';
+    final Object cachedValue = new Object();
+    final String notCachedId = '2';
+    final Object notCachedValue = new Object();
+    final String putId = '3';
+    final Object putValue = new Object();
+
+    setUp(() async {
+      cache = new Cache();
+      await cache.get(cachedId, () => cachedValue);
+
+      cacheEvents = new CacheEvents(cache);
+    });
+
+    group('get', () {
+      test('should return cached value when identifier is cached', () async {
+        var value = await cache.get(cachedId, () => notCachedValue);
+        expect(value, same(cachedValue));
+      });
+
+      test(
+          'should return same value when called successively '
+          'syncronously', () async {
+        var cachedValues = <Future<Object>>[
+          cache.get(notCachedId, () => notCachedValue),
+          cache.get(notCachedId, () => new Object())
+        ];
+        var completedValues = await Future.wait(cachedValues);
+        expect(completedValues[0], same(notCachedValue));
+        expect(completedValues[1], same(notCachedValue));
+      });
+
+      test('should return factory value when identifier is not cached',
+          () async {
+        var value = await cache.get(notCachedId, () => notCachedValue);
+        expect(value, same(notCachedValue));
+      });
+
+      test('should call valueFactory if identifier is not cached', () async {
+        var didCallValueFactory = false;
+        await cache.get(notCachedId, () {
+          didCallValueFactory = true;
+          return notCachedValue;
+        });
+        expect(didCallValueFactory, isTrue);
+      });
+
+      test('should not call valueFactory if id is cached', () async {
+        var didCallValueFactory = false;
+        await cache.get(notCachedId, () {
+          didCallValueFactory = true;
+          return notCachedValue;
+        });
+        expect(didCallValueFactory, isTrue);
+      });
+
+      test('should not dispatch didUpdate event on cached get', () async {
+        cache.didUpdate
+            .listen(expectAsync1((CacheContext context) {}, count: 0));
+        await cache.get(cachedId, () => new Object());
+      });
+
+      test('should dispatch didUpdate event on uncached get', () async {
+        cache.didUpdate.listen(expectAsync1((CacheContext context) {
+          expect(context.id, notCachedId);
+          expect(context.value, notCachedValue);
+        }));
+        await cache.get(notCachedId, () => notCachedValue);
+      });
+
+      test('should call onGet when value is not cached', () async {
+        ChildCache childCache = new ChildCache();
+        await childCache.get(cachedId, () => cachedValue);
+        expect(childCache.onGetId, cachedId);
+        expect(childCache.onGetValue, cachedValue);
+      });
+
+      test('should call onGet when value is cached', () async {
+        ChildCache childCache = new ChildCache();
+        await childCache.put(putId, putValue);
+        await childCache.get(putId, () => notCachedValue);
+        expect(childCache.onGetId, putId);
+        expect(childCache.onGetValue, putValue);
+      });
+
+      test('should throw when disposed', () async {
+        await cache.dispose();
+        expect(() => cache.get(cachedId, () => cachedValue), throwsStateError);
+      });
+    });
+
+    group('isCached', () {
+      test('should return false when identifier has not been cached', () {
+        expect(cache.isCached(notCachedId), isFalse);
+      });
+
+      test('should return true when identifier has been cached', () {
+        expect(cache.isCached(cachedId), isTrue);
+      });
+
+      test('should return false when identifier has been removed', () async {
+        await cache.remove(cachedId);
+        expect(cache.isCached(cachedId), isFalse);
+      });
+
+      test('should throw when disposed', () async {
+        await cache.dispose();
+        expect(
+            () => cache.get(cachedId, () => notCachedValue), throwsStateError);
+      });
+    });
+
+    group('put', () {
+      test('should update cache', () async {
+        await cache.put(putId, putValue);
+        final getValue = await cache.get(putId, () => null);
+        expect(getValue, same(putValue));
+      });
+
+      test('should call onPut', () async {
+        final ChildCache childCache = new ChildCache();
+
+        await childCache.put(putId, putValue);
+        expect(childCache.onPutId, putId);
+        expect(childCache.onPutValue, putValue);
+      });
+
+      test('should put syncronously', () {
+        final getA = cache.getAsync(notCachedId, () async {
+          await new Future.delayed(new Duration(milliseconds: 100));
+          return notCachedValue;
+        });
+
+        final put = cache.put(notCachedId, putValue);
+        final getB = cache.get(notCachedId, () => new Object());
+
+        getA.then(expectAsync1(
+            (Object value) => expect(value, same(notCachedValue))));
+        getB.then(
+            expectAsync1((Object value) => expect(value, same(putValue))));
+        put.then(expectAsync1((Object value) => expect(value, same(putValue))));
+      });
+
+      test('should throw when disposed', () async {
+        await cache.dispose();
+        expect(() => cache.put(putId, null), throwsStateError);
+      });
+    });
+
+    group('remove', () {
+      test('should dispatch one didUpdate event when identifier is removed',
+          () async {
+        cache.didUpdate.listen(expectAsync1((CacheContext context) {
+          expect(context.id, cachedId);
+          expect(context.value, isNull);
+        }, count: 1));
+        await cache.remove(cachedId);
+        await cache.remove(cachedId);
+      });
+
+      test(
+          'should dispatch one didUpdate event when identifier is removed '
+          'syncronously', () {
+        cache.didUpdate.listen(expectAsync1((CacheContext context) {
+          expect(context.id, cachedId);
+          expect(context.value, isNull);
+        }, count: 1));
+        cache.remove(cachedId);
+        cache.remove(cachedId);
+      });
+
+      test('should dispatch one didRemove event when identifier is removed',
+          () async {
+        cache.didRemove.listen(expectAsync1((CacheContext context) {
+          expect(context.id, cachedId);
+          expect(context.value, cachedValue);
+        }, count: 1));
+        await cache.remove(cachedId);
+        await cache.remove(cachedId);
+      });
+
+      test(
+          'should dispatch one didRemove event when identifier is removed '
+          'syncronously', () {
+        cache.didRemove.listen(expectAsync1((CacheContext context) {
+          expect(context.id, cachedId);
+          expect(context.value, cachedValue);
+        }, count: 1));
+        cache.remove(cachedId);
+        cache.remove(cachedId);
+      });
+
+      test('should not dispatch didUpdate event when identifier is not cached',
+          () async {
+        cache.didUpdate.listen(expectAsync1((CacheContext _) {}, count: 0));
+        await cache.remove(notCachedId);
+      });
+
+      test('should call onRemove when value was cached', () async {
+        ChildCache childCache = new ChildCache();
+        await childCache.get(cachedId, () => cachedValue);
+        await childCache.remove(cachedId);
+        expect(childCache.onRemoveId, cachedId);
+        expect(childCache.onRemoveValue, cachedValue);
+      });
+
+      test('should not call onRemove when identifer is not cached', () async {
+        ChildCache childCache = new ChildCache();
+        await childCache.remove(cachedId);
+        expect(childCache.onRemoveId, isNull);
+        expect(childCache.onRemoveValue, isNull);
+      });
+
+      test('should remove after pending get if called syncronously', () {
+        cache.get(notCachedId, () => notCachedValue);
+        cache.remove(notCachedId).then(expectAsync1((Null _) {
+          expect(cacheEvents.ids, [notCachedId, notCachedId]);
+          expect(cacheEvents.values, [notCachedValue, null]);
+        }));
+      });
+
+      test('should remove after pending getAsync if called syncronously', () {
+        cache.getAsync(notCachedId, () async {
+          await new Future.delayed(new Duration(milliseconds: 100));
+          return notCachedValue;
+        });
+        cache.remove(notCachedId).then(expectAsync1((Null _) {
+          expect(cacheEvents.ids, [notCachedId, notCachedId]);
+          expect(cacheEvents.values, [notCachedValue, null]);
+        }));
+      });
+
+      test('should remove after pending put if called syncronously', () {
+        cache.put(putId, putValue);
+        cache.remove(putId).then(expectAsync1((Null _) {
+          expect(cacheEvents.ids, [putId, putId]);
+          expect(cacheEvents.values, [putValue, null]);
+        }));
+      });
+
+      test('should throw when disposed', () async {
+        await cache.dispose();
+        expect(() => cache.remove(cachedId), throwsStateError);
+      });
+    });
+  });
+}
+
+class CacheEvents<TIdentifier, TValue> {
+  final Cache<TIdentifier, TValue> _cache;
+  List<TIdentifier> _ids = <TIdentifier>[];
+  List<TValue> _values = <TValue>[];
+
+  CacheEvents(this._cache) {
+    _cache.didUpdate.listen((CacheContext<TIdentifier, TValue> context) {
+      _ids.add(context.id);
+      _values.add(context.value);
+    });
+  }
+
+  Iterable<TIdentifier> get ids => _ids;
+
+  Iterable<TValue> get values => _values;
+}
+
+class ChildCache extends Cache<String, Object> {
+  String onGetId;
+  Object onGetValue;
+  String onPutId;
+  Object onPutValue;
+  String onRemoveId;
+  Object onRemoveValue;
+
+  @override
+  Future<Null> onGet(String id, Object value) async {
+    onGetId = id;
+    onGetValue = value;
+  }
+
+  @override
+  Future<Null> onRemove(String id, Object value) async {
+    onRemoveId = id;
+    onRemoveValue = value;
+  }
+
+  @override
+  Future<Null> onPut(String id, Object value) async {
+    onPutId = id;
+    onPutValue = value;
+  }
+}

--- a/test/unit/vm/cache/reference_cache_test.dart
+++ b/test/unit/vm/cache/reference_cache_test.dart
@@ -1,0 +1,88 @@
+import 'package:test/test.dart';
+
+import 'package:w_common/src/cache/cache.dart';
+import 'package:w_common/src/cache/reference_cache.dart';
+
+void main() {
+  group('ReferenceCache', () {
+    ReferenceCache<String, Object> cache;
+    final String cachedId = '1';
+    final Object cachedValue = new Object();
+    final String notCachedId = '2';
+
+    setUp(() async {
+      cache = new ReferenceCache();
+      await cache.get(cachedId, () => cachedValue);
+    });
+
+    group('onGet', () {
+      test('should increment reference count', () async {
+        expect(cache.referenceCount(cachedId), 1);
+        await cache.get(cachedId, () => null);
+        expect(cache.referenceCount(cachedId), 2);
+      });
+    });
+
+    group('onPut', () {
+      test('should set reference count to 1', () async {
+        await cache.get(cachedId, () => null);
+        await cache.get(cachedId, () => null);
+        expect(cache.referenceCount(cachedId), 3);
+        await cache.put(cachedId, new Object());
+        expect(cache.referenceCount(cachedId), 1);
+      });
+    });
+    
+    group('onRemove', () {
+      test('should reset reference count to 0', () async {
+        expect(cache.referenceCount(cachedId), 1);
+        await cache.remove(cachedId);
+        expect(cache.referenceCount(cachedId), 0);
+      });
+    });
+
+    group('referenceCount', () {
+      test('should return number of get calls', () async {
+        expect(cache.referenceCount(cachedId), 1);
+        await cache.get(cachedId, () => cachedValue);
+        expect(cache.referenceCount(cachedId), 2);
+      });
+
+      test('should return zero for uncached results', () {
+        expect(cache.referenceCount(notCachedId), 0);
+      });
+    });
+
+    group('release', () {
+      test('should not decrement referenceCount below zero', () async {
+        expect(cache.referenceCount(notCachedId), 0);
+        await cache.release(notCachedId);
+        expect(cache.referenceCount(notCachedId), 0);
+      });
+
+      test(
+          'should not remove identifier form cache when reference '
+          'count is greater than 1', () async {
+        cache.didUpdate.listen(expectAsync1((CacheContext _) {}, count: 0));
+        await cache.get(cachedId, () => cachedValue);
+        expect(cache.referenceCount(cachedId), 2);
+        await cache.release(cachedId);
+      });
+
+      test(
+          'should remove identifier from cache when last reference '
+          'is released', () async {
+        cache.didUpdate.listen((CacheContext context) {
+          expect(context.id, cachedId);
+          expect(context.value, null);
+        });
+        await cache.release(cachedId);
+      });
+
+      test('should throw StateError when disposed', () async {
+        await cache.dispose();
+        expect(() => cache.release(cachedId), throwsStateError);
+      });
+    });
+  });
+}

--- a/test/unit/vm/cache/reference_cache_test.dart
+++ b/test/unit/vm/cache/reference_cache_test.dart
@@ -32,7 +32,7 @@ void main() {
         expect(cache.referenceCount(cachedId), 1);
       });
     });
-    
+
     group('onRemove', () {
       test('should reset reference count to 0', () async {
         expect(cache.referenceCount(cachedId), 1);

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -17,8 +17,6 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:w_common/disposable.dart';
 
-import '../typedefs.dart';
-
 class DisposableThing extends Object with Disposable {
   bool wasOnDisposeCalled = false;
 
@@ -89,7 +87,8 @@ void main() {
       test(
           'should call callback and accept null return value'
           'when parent is disposed', () async {
-        thing.testManageDisposer(expectAsync(() => null, count: 1) as Disposer);
+        thing
+            .testManageDisposer(expectAsync0(() => null, count: 1) as Disposer);
         await thing.dispose();
       });
 
@@ -97,7 +96,7 @@ void main() {
           'should call callback and accept Future return value'
           'when parent is disposed', () async {
         thing.testManageDisposer(
-            expectAsync(() => new Future(() {}), count: 1) as Disposer);
+            expectAsync0(() => new Future(() {}), count: 1));
         await thing.dispose();
       });
 
@@ -118,9 +117,9 @@ void main() {
       test('should close a single-subscription stream when parent is disposed',
           () async {
         var controller = new StreamController();
-        var subscription = controller.stream
-            .listen(expectAsync(([_]) {}, count: 0) as StreamListener);
-        subscription.onDone(expectAsync(([_]) {}, count: 1) as StreamListener);
+        var subscription =
+            controller.stream.listen(expectAsync1(([_]) {}, count: 0));
+        subscription.onDone(expectAsync1(([_]) {}, count: 1));
         thing.testManageStreamController(controller);
         expect(controller.isClosed, isFalse);
         await thing.dispose();
@@ -148,9 +147,9 @@ void main() {
     group('manageStreamSubscription', () {
       test('should cancel subscription when parent is disposed', () async {
         var controller = new StreamController();
-        controller.onCancel = expectAsync(([_]) {}, count: 1);
-        var subscription = controller.stream
-            .listen(expectAsync((_) {}, count: 0) as StreamListener);
+        controller.onCancel = expectAsync1(([_]) {}, count: 1);
+        var subscription =
+            controller.stream.listen(expectAsync1((_) {}, count: 0));
         thing.testManageStreamSubscription(subscription);
         await thing.dispose();
         controller.add(null);

--- a/test/unit/vm/generated_vm_tests.dart
+++ b/test/unit/vm/generated_vm_tests.dart
@@ -1,11 +1,15 @@
 @TestOn('vm')
 library test.unit.vm.generated_vm_tests;
 
+import './cache/cache_test.dart' as cache_cache_test;
+import './cache/reference_cache_test.dart' as cache_reference_cache_test;
 import './disposable_test.dart' as disposable_test;
 import './func_test.dart' as func_test;
 import 'package:test/test.dart';
 
 void main() {
+  cache_cache_test.main();
+  cache_reference_cache_test.main();
   disposable_test.main();
   func_test.main();
 }


### PR DESCRIPTION
### Description

The need to remove duplicates from or maintain a collection of instances of a particular class demands the need for a Cache implementation. The Cache should allow consumers to obtain a value from the cache or call an underlying factory, explicitly put an item in the Cache, and remove items from a Cache.

### Changes

Implement the base Cache implementation. The get, getAsync, put, and remove operations allow consumers to interact with the Cache as described. Lifecycle methods and an update stream are provided allowing consumers to extend the cache and implement custom behaviors or observe the cache changes.

A specialization of the Cache is the ReferenceCache which maintains a list of accesses from the Cache. Consumers can release a reference from the cache which decrements the reference count. If the number of releases equals the number of gets, the item is removed from the ReferenceCache. This effectively allows consumers to memoize shared resources.

For example:

```dart

Func<Future<Thing>> buildThingFactory() {
    ReferenceCache<String, HeavyNetworkConnector> cache = new ReferenceCache<String, HeavyNetworkConnector>()
    cache.didRemove.listen((String id, HeavyNetworkConnection connector) {
        print('Last reference to connection $id has been released: disposing');
        connection.dispose();
    });

    return (String thingId) async {
        final connection = await cache.getAsync(thingId, () => _expensiveOpToInitConnection(thingId));
        final thing =  new Thing(networkConnection: connection)
            ..didDispose.then((Null _) => cache.remove(thingId));

        return thing;
    }
}
```

Or you can cache function results via composing a cache:

```dart
class HeavyOp {
    Cache<Token, OpResult> _cache = new Cache<Token, OpResult>();

    Future<OpResult> runOp(Token opParam) async {
        final value = await _cache.get(opToken, () => _executeOp(opParam));
        
        // Cache results are invalidated after thirty seconds.
        new Timer(new Duration(seconds: 30), () {
            _cache.remove(opParam);
        });

        return value
    }

    OpResult _executeOp(Token opParam) {
        /// lengthy computation 
        return result;
    }
}
```

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf
@todbachman-wf 
@georgelesica-wf 
@aaronstgeorge-wf 

