### PR TITLE
Add toJsonString() method to JsonSerializable

### DIFF
--- a/lib/json_serializable.dart
+++ b/lib/json_serializable.dart
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+import 'dart:convert';
 
 /// Abstract class that identifies other classes being serializable as json.
 ///
@@ -27,4 +28,7 @@ abstract class JsonSerializable {
   ///     return fieldMap;
   ///   }
   Map<String, dynamic> toJson();
+
+  /// Returns a String in JSON format representing the serialized class.
+  String toJsonString() => JSON.encode(this);
 }

--- a/test/unit/vm/generated_vm_tests.dart
+++ b/test/unit/vm/generated_vm_tests.dart
@@ -3,9 +3,11 @@ library test.unit.vm.generated_vm_tests;
 
 import './disposable_test.dart' as disposable_test;
 import './func_test.dart' as func_test;
+import './json_serializable_test.dart' as json_serializable_test;
 import 'package:test/test.dart';
 
 void main() {
   disposable_test.main();
   func_test.main();
+  json_serializable_test.main();
 }

--- a/test/unit/vm/json_serializable_test.dart
+++ b/test/unit/vm/json_serializable_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2016 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert';
+
+import 'package:test/test.dart';
+
+import 'package:w_common/json_serializable.dart';
+
+class TestJsonPayload extends JsonSerializable {
+  String a;
+  String b;
+
+  TestJsonPayload(this.a, this.b);
+
+  @override
+  Map<String, String> toJson() {
+    return {'a': a, 'b': b};
+  }
+}
+
+main() {
+  group('JsonSerializable', () {
+    test('.toJsonString() should serialize the class to JSON', () {
+      final obj = new TestJsonPayload('hello', 'world');
+      expect(obj.toJsonString(), equals(JSON.encode(obj.toJson())));
+    });
+  });
+}


### PR DESCRIPTION
### Description
Adds a `toJsonString()` method to `JsonSerializable` to reduce legwork of consumers working with actual JSON strings. Prevents the needs for consumers to import `dart:convert` and wrap the object in `JSON.encode()` calls.

As I'm making this PR I'm realizing there may be objections to this as it prevents use from being able to easily use this as an interface (via `implements`) and instead works better with `extends` or `with`. If everyone objects, we can close this, but I thought I'd at least put it up for debate/posterity.


### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [x] Major
  - [x] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review
@Workiva/web-platform-pp 
@Workiva/rich-app-platform-pp 
