### PR TITLE
RAP-1716 Add some additional management and helper methods

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -34,7 +34,6 @@ linter:
     - library_names
     - library_prefixes
     - non_constant_identifier_names
-    - one_member_abstracts
     - only_throw_errors
     - overridden_fields
     - package_api_docs

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -164,10 +164,11 @@ typedef Future<dynamic> Disposer();
 /// without explicit reference to [Disposable]. To do this, we use
 /// composition to include the [Disposable] machinery without changing
 /// the public interface of our class or polluting its lifecycle.
-class Disposable implements _Disposable, DisposableManagerV2 {
+class Disposable implements _Disposable, DisposableManagerV3 {
+  List<Future<dynamic>> _awaitableFutures = <Future<dynamic>>[];
   Completer<Null> _didDispose = new Completer<Null>();
+  List<_Disposable> _internalDisposables = <_Disposable>[];
   bool _isDisposing = false;
-  List<_Disposable> _internalDisposables = [];
 
   /// A [Future] that will complete when this object has been disposed.
   Future<Null> get didDispose => _didDispose.future;
@@ -189,6 +190,19 @@ class Disposable implements _Disposable, DisposableManagerV2 {
   /// and will become `false` once the [didDispose] future completes.
   bool get isDisposing => _isDisposing;
 
+  @mustCallSuper
+  @override
+  Future<T> awaitBeforeDispose<T>(Future<T> future) {
+    _throwOnInvalidCall('awaitBeforeDispose', 'future', future);
+    _awaitableFutures.add(future);
+    future.then((_) {
+      _awaitableFutures.remove(future);
+    }).catchError((_) {
+      _awaitableFutures.remove(future);
+    });
+    return future;
+  }
+
   /// Dispose of the object, cleaning up to prevent memory leaks.
   @override
   Future<Null> dispose() async {
@@ -200,17 +214,25 @@ class Disposable implements _Disposable, DisposableManagerV2 {
     }
     _isDisposing = true;
 
-    List<Future> futures = []
+    List<Future<dynamic>> futures = []
       ..addAll(_internalDisposables.map((disposable) => disposable.dispose()))
       ..add(onDispose());
-
     _internalDisposables = [];
+
+    futures.addAll(_awaitableFutures);
+    _awaitableFutures = [];
 
     // We need to filter out nulls because a subscription cancel
     // method is allowed to return a plain old null value.
     return Future
         .wait(futures.where((future) => future != null))
         .then(_completeDisposeFuture);
+  }
+
+  @mustCallSuper
+  @override
+  Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) {
+    return null;
   }
 
   @mustCallSuper
@@ -231,22 +253,38 @@ class Disposable implements _Disposable, DisposableManagerV2 {
 
   @mustCallSuper
   @override
+  Completer<T> manageCompleter<T>(Completer<T> completer) {
+    _throwOnInvalidCall('manageCompleter', 'completer', completer);
+    var disposable = new _InternalDisposable(() async {
+      if (!completer.isCompleted) {
+        completer.completeError(new ObjectDisposedException());
+      }
+    });
+    _internalDisposables.add(disposable);
+    completer.future.then((_) {
+      _internalDisposables.remove(disposable);
+    });
+    return completer;
+  }
+
+  @mustCallSuper
+  @override
   void manageDisposable(Disposable disposable) {
-    _throwIfNull(disposable, 'disposable');
+    _throwOnInvalidCall('manageDisposable', 'disposable', disposable);
     _internalDisposables.add(disposable);
   }
 
   @mustCallSuper
   @override
   void manageDisposer(Disposer disposer) {
-    _throwIfNull(disposer, 'disposer');
+    _throwOnInvalidCall('manageDisposer', 'disposer', disposer);
     _internalDisposables.add(new _InternalDisposable(disposer));
   }
 
   @mustCallSuper
   @override
   void manageStreamController(StreamController controller) {
-    _throwIfNull(controller, 'controller');
+    _throwOnInvalidCall('manageStreamController', 'controller', controller);
     _internalDisposables.add(new _InternalDisposable(() {
       if (!controller.hasListener) {
         controller.stream.listen((_) {});
@@ -258,7 +296,8 @@ class Disposable implements _Disposable, DisposableManagerV2 {
   @mustCallSuper
   @override
   void manageStreamSubscription(StreamSubscription subscription) {
-    _throwIfNull(subscription, 'subscription');
+    _throwOnInvalidCall(
+        'manageStreamSubscription', 'subscription', subscription);
     _internalDisposables
         .add(new _InternalDisposable(() => subscription.cancel()));
   }
@@ -269,12 +308,6 @@ class Disposable implements _Disposable, DisposableManagerV2 {
     return null;
   }
 
-  Null _completeDisposeFuture(List<dynamic> _) {
-    _didDispose.complete();
-    _isDisposing = false;
-    return null;
-  }
-
   void _addObservableTimerDisposable(_ObservableTimer timer) {
     _InternalDisposable disposable =
         new _InternalDisposable(() async => timer.cancel());
@@ -282,9 +315,23 @@ class Disposable implements _Disposable, DisposableManagerV2 {
     timer.didConclude.then((Null _) => _internalDisposables.remove(disposable));
   }
 
-  void _throwIfNull(dynamic argument, String name) {
-    if (argument == null) {
-      throw new ArgumentError.notNull(name);
+  Null _completeDisposeFuture(List<dynamic> _) {
+    _didDispose.complete();
+    _isDisposing = false;
+    return null;
+  }
+
+  void _throwOnInvalidCall(
+      String methodName, String parameterName, dynamic parameterValue) {
+    if (parameterValue == null) {
+      throw new ArgumentError.notNull(parameterName);
+    }
+    if (isDisposing) {
+      throw new StateError('$methodName not allowed, object is disposing');
+    }
+    if (isDisposed) {
+      throw new StateError(
+          '$methodName not allowed, object is already disposed');
     }
   }
 }

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -255,15 +255,20 @@ class Disposable implements _Disposable, DisposableManagerV3 {
   @override
   Completer<T> manageCompleter<T>(Completer<T> completer) {
     _throwOnInvalidCall('manageCompleter', 'completer', completer);
+
     var disposable = new _InternalDisposable(() async {
       if (!completer.isCompleted) {
         completer.completeError(new ObjectDisposedException());
       }
     });
     _internalDisposables.add(disposable);
-    completer.future.then((_) {
+
+    completer.future.catchError((e) {
+      _internalDisposables.remove(disposable);
+    }).then((_) {
       _internalDisposables.remove(disposable);
     });
+
     return completer;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,9 +11,8 @@ dependencies:
   meta: ^1.0.4
 
 dev_dependencies:
-  analyzer: ^0.27.3
   coverage: ^0.7.2
-  dart_dev: ^1.4.1
-  dart_style: ^0.2.4
-  dartdoc: ^0.8.0
+  dart_dev: ^1.7.2
+  dart_style: ^0.2.16
+  dartdoc: ^0.9.0
   test: ^0.12.4

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -19,7 +19,7 @@ import 'package:w_common/disposable.dart';
 
 import 'typedefs.dart';
 
-class DisposableThing extends Object with Disposable {
+class DisposableThing extends Disposable {
   bool wasOnDisposeCalled = false;
 
   void testManageDisposable(Disposable thing) {

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -22,22 +22,6 @@ import 'typedefs.dart';
 class DisposableThing extends Disposable {
   bool wasOnDisposeCalled = false;
 
-  void testManageDisposable(Disposable thing) {
-    manageDisposable(thing);
-  }
-
-  void testManageDisposer(Disposer disposer) {
-    manageDisposer(disposer);
-  }
-
-  void testManageStreamController(StreamController controller) {
-    manageStreamController(controller);
-  }
-
-  void testManageStreamSubscription(StreamSubscription subscription) {
-    manageStreamSubscription(subscription);
-  }
-
   @override
   Future<Null> onDispose() {
     expect(isDisposed, isFalse);


### PR DESCRIPTION
### Description

Based on some of our discussions around memory leaks and best practices I decided to add a few more, hopefully helpful utility methods.

### Changes

Add the following:

  * `Future<T> awaitBeforeDispose<T>(Future<T> future)` - causes the object to await the given future before disposing. The future itself is returned for convenience.
  * `Future<T> getManagedDelayedFuture<T>(Duration duration, T callback())` - returns a delayed future that will complete with the result of calling `callback` after a specific duration. If the object is disposed before the duration has elapsed the future will still complete, but with an `ObjectDisposedException` error.
  * `Completer<T> manageCompleter<T>(Completer<T> completer)` - manages a completer by completing it with an `ObjectDisposedException` error if the object is disposed before the completer has completed.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [x] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf
@Workiva/rich-app-platform-pp 

