### PR TITLE
RAP-1780 Handle single-subscription stream controllers better

### DIFF
--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -317,6 +317,7 @@ class Disposable implements _Disposable, DisposableManagerV3 {
     });
     controller.done.then((_) {
       isDone = true;
+      _internalDisposables.remove(disposable);
       disposable.dispose();
     });
     _internalDisposables.add(disposable);

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -262,8 +262,29 @@ void main() {
       });
 
       test(
-          'should close a single-subscription stream with no listener'
-          'when parent is disposed', () async {
+          'should complete normally for a single-subscription stream with '
+          'a listener that has been closed when parent is disposed', () async {
+        var controller = new StreamController();
+        var sub = controller.stream.listen(expectAsync1((_) {}, count: 0));
+        thing.manageStreamController(controller);
+        await controller.close();
+        await thing.dispose();
+        await sub.cancel();
+      });
+
+      test(
+          'should complete normally for a single-subscription stream with a '
+          'canceled listener when parent is disposed', () async {
+        var controller = new StreamController();
+        var sub = controller.stream.listen(expectAsync1((_) {}, count: 0));
+        thing.manageStreamController(controller);
+        await sub.cancel();
+        await thing.dispose();
+      });
+
+      test(
+          'should close a single-subscription stream that never had a '
+          'listener when parent is disposed', () async {
         var controller = new StreamController();
         thing.manageStreamController(controller);
         expect(controller.isClosed, isFalse);

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -262,8 +262,8 @@ void main() {
       });
 
       test(
-          'should complete normally for a single-subscription stream with '
-          'a listener that has been closed when parent is disposed', () async {
+          'should allow subscriptions for a single-subscription stream to be '
+          'cancelled after parent has been disposed', () async {
         var controller = new StreamController();
         var sub = controller.stream.listen(expectAsync1((_) {}, count: 0));
         thing.manageStreamController(controller);

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -262,8 +262,8 @@ void main() {
       });
 
       test(
-          'should allow subscriptions for a single-subscription stream to be '
-          'cancelled after parent has been disposed', () async {
+          'should complete normally for a single-subscription stream, with '
+          'a listener, that has been closed when parent is disposed', () async {
         var controller = new StreamController();
         var sub = controller.stream.listen(expectAsync1((_) {}, count: 0));
         thing.manageStreamController(controller);


### PR DESCRIPTION
### Description

There are two situations in which managing a single-subscription stream controller will result in an exception on dispose.

  1. The stream has already been closed
  2. The stream had a listener and that listener was subsequently canceled *before* disposal occurred

### Changes

Use some hackery to figure out if the stream was listened-to and the listener subsequently canceled its subscription. Also, check to see if the stream was already closed before we try to listen to it again.

As an aside, the reason we listen to the stream before closing the controller is that closing a controller that has never had a listener will cause an exception to be thrown.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

We probably want @dustinlessard-wf and / or @bencampbell-wf to give this a glance to make sure I haven't introduced any new memory leaks.

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

### FYI

@seanburke-wf 
@bencampbell-wf 