### PR TITLE
BREAKING CHANGE - Flux Stores can call dispose with awaitAnimationFrame: true and protect everyone from batched redraw collisions. 🚓

### DIFF
--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -214,7 +214,8 @@ class Disposable implements _Disposable, DisposableManagerV3 {
     }
     _isDisposing = true;
 
-    if (awaitAnimationFrame) await new Future.delayed(new Duration(milliseconds: 17));
+    if (awaitAnimationFrame)
+      await new Future.delayed(new Duration(milliseconds: 17));
 
     List<Future<dynamic>> futures = []
       ..addAll(_internalDisposables.map((disposable) => disposable.dispose()))

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -205,7 +205,7 @@ class Disposable implements _Disposable, DisposableManagerV3 {
 
   /// Dispose of the object, cleaning up to prevent memory leaks.
   @override
-  Future<Null> dispose() async {
+  Future<Null> dispose({bool awaitAnimationFrame: false}) async {
     if (isDisposed) {
       return null;
     }
@@ -213,6 +213,8 @@ class Disposable implements _Disposable, DisposableManagerV3 {
       return didDispose;
     }
     _isDisposing = true;
+
+    if (awaitAnimationFrame) await new Future.delayed(new Duration(milliseconds: 17));
 
     List<Future<dynamic>> futures = []
       ..addAll(_internalDisposables.map((disposable) => disposable.dispose()))

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -42,7 +42,7 @@ class DisposableThing extends Disposable {
 class DisposeCounter extends Disposable {
   int disposeCount = 0;
   @override
-  Future<Null> dispose() {
+  Future<Null> dispose({bool awaitAnimationFrame: false}) {
     disposeCount++;
     return super.dispose();
   }


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description
Calling dispose on a flux store before its components' batched redraws have finished can cause that pending redraw to attempt to subscribe to a disposed store's onData stream.  Exceptions abound.  All consumers shouldn't have to know and worry about it.

### Changes
Allow disposable to optionally wait for the length of an animation frame.  

w_flux Store class would call dispose with awaitAnimationFrame: true.  So, the first store to dispose would wait for 17ms, but all internal stores that are looped through would not wait.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [x] Major
  - [x] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review
@georgelesica-wf 
@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

