### PR TITLE
RAP-2040 Large number of managed disposables cause massive GC hit

### DIFF
--- a/lib/src/disposable/disposable_manager.dart
+++ b/lib/src/disposable/disposable_manager.dart
@@ -41,6 +41,11 @@ abstract class DisposableManager {
 
   /// Automatically cancel a stream subscription when this object is disposed.
   ///
+  /// This method should not be used for subscriptions that will be canceled
+  /// manually by the consumer because we have no way of knowing when a
+  /// subscription is canceled, so we will hold on to the reference until the
+  /// parent object is disposed.
+  ///
   /// The parameter may not be `null`.
   void manageStreamSubscription(StreamSubscription subscription);
 }


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description

When there are a large number of managed disposables (10k+), disposal of the managing object causes a large number of garbage collections apparently due to the list of futures that we build in the dispose() method.

### Changes

This isn't a perfect solution (yet) but I think it improves things a bit. We don't build a list of futures. Instead we await them one at a time in a for-loop.

This would perform much better if we didn't have to check to `isDisposedOrDisposing` in the callbacks we set up on management. However, these are necessary, for now, because the documented semantics allow most managed objects to be disposed / closed out-of-band. This means we have to handle that event to prevent memory leaks, so on dispose we have to remove each one from the list of disposables we maintain.

### Semantic Versioning

- [x] **Patch**
  - [ ] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes
- [ ] See me for a +10 walkthrough

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

