### PR TITLE
RAP-2050 Add dev tooling

### DIFF
--- a/example/disposable/example.dart
+++ b/example/disposable/example.dart
@@ -64,12 +64,8 @@ void main() {
   });
 
   disposeButton.onClick.listen((_) {
-    var startTime = new DateTime.now().millisecondsSinceEpoch;
     treeRoot.dispose().then((_) {
-      var endTime = new DateTime.now().millisecondsSinceEpoch;
-      var delta = endTime - startTime;
       addToOutput('Disposable tree size: ${treeRoot.disposalTreeSize}');
-      addToOutput('Disposable took ${delta / 1000} seconds to dispose');
       outputBox.scrollTo(0, outputBox.scrollHeight);
       treeRoot = null;
     });

--- a/example/disposable/example.dart
+++ b/example/disposable/example.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'dart:html';
+
+import 'package:logging/logging.dart';
+import 'package:w_common/disposable.dart';
+
+int childCount;
+int treeDepth;
+StreamController controller;
+
+Disposable createDisposableTree(int depth) {
+  var child = new Disposable();
+
+  for (int i = 0; i < childCount; i++) {
+    child.manageStreamController(new StreamController());
+    child.manageStreamSubscription(controller.stream.listen((_) {}));
+  }
+
+  if (depth == 0) {
+    return child;
+  }
+
+  for (int i = 0; i < childCount; i++) {
+    child.manageDisposable(createDisposableTree(depth - 1));
+  }
+
+  return child;
+}
+
+void main() {
+  Logger.root.onRecord.listen((LogRecord rec) {
+    print('${rec.level.name}: ${rec.time}: ${rec.message}');
+  });
+  Logger.root.level = Level.INFO;
+
+  Disposable.enableDebugMode();
+
+  ButtonElement createButton = querySelector('#create-button');
+  ButtonElement disposeButton = querySelector('#dispose-button');
+  InputElement childCountField = querySelector('#child-count-field');
+  InputElement treeDepthField = querySelector('#tree-depth-field');
+
+  Disposable treeRoot;
+
+  createButton.onClick.listen((_) {
+    controller?.close();
+
+    if (treeRoot != null) {
+      window.alert('Dispose before creating a new tree');
+    }
+
+    childCount = int.parse(childCountField.value);
+    treeDepth = int.parse(treeDepthField.value);
+    controller = new StreamController.broadcast();
+
+    treeRoot = createDisposableTree(treeDepth);
+    print('Disposable tree size: ${treeRoot.disposalTreeSize}');
+  });
+
+  disposeButton.onClick.listen((_) {
+    treeRoot.dispose().then((_) {
+      print('Disposable tree size: ${treeRoot.disposalTreeSize}');
+      treeRoot = null;
+    });
+  });
+}

--- a/example/disposable/example.dart
+++ b/example/disposable/example.dart
@@ -12,11 +12,6 @@ ButtonElement createButton = querySelector('#create-button');
 ButtonElement disposeButton = querySelector('#dispose-button');
 InputElement childCountField = querySelector('#child-count-field');
 InputElement treeDepthField = querySelector('#tree-depth-field');
-TextAreaElement outputBox = querySelector('#output-box');
-
-void addToOutput(String output) {
-  outputBox.value += output + '\n';
-}
 
 Disposable createDisposableTree(int depth) {
   var child = new Disposable();
@@ -39,7 +34,7 @@ Disposable createDisposableTree(int depth) {
 
 void main() {
   Logger.root.onRecord.listen((LogRecord rec) {
-    addToOutput('${rec.level.name}: ${rec.time}: ${rec.message}');
+    print('${rec.level.name}: ${rec.time}: ${rec.message}');
   });
   Logger.root.level = Level.INFO;
 
@@ -59,14 +54,12 @@ void main() {
     controller = new StreamController.broadcast();
 
     treeRoot = createDisposableTree(treeDepth);
-    addToOutput('Disposable tree size: ${treeRoot.disposalTreeSize}');
-    outputBox.scrollTo(0, outputBox.scrollHeight);
+    print('Disposable tree size: ${treeRoot.disposalTreeSize}');
   });
 
   disposeButton.onClick.listen((_) {
     treeRoot.dispose().then((_) {
-      addToOutput('Disposable tree size: ${treeRoot.disposalTreeSize}');
-      outputBox.scrollTo(0, outputBox.scrollHeight);
+      print('Disposable tree size: ${treeRoot.disposalTreeSize}');
       treeRoot = null;
     });
   });

--- a/example/disposable/example.dart
+++ b/example/disposable/example.dart
@@ -8,6 +8,16 @@ int childCount;
 int treeDepth;
 StreamController controller;
 
+ButtonElement createButton = querySelector('#create-button');
+ButtonElement disposeButton = querySelector('#dispose-button');
+InputElement childCountField = querySelector('#child-count-field');
+InputElement treeDepthField = querySelector('#tree-depth-field');
+TextAreaElement outputBox = querySelector('#output-box');
+
+void addToOutput(String output) {
+  outputBox.value += output + '\n';
+}
+
 Disposable createDisposableTree(int depth) {
   var child = new Disposable();
 
@@ -29,16 +39,11 @@ Disposable createDisposableTree(int depth) {
 
 void main() {
   Logger.root.onRecord.listen((LogRecord rec) {
-    print('${rec.level.name}: ${rec.time}: ${rec.message}');
+    addToOutput('${rec.level.name}: ${rec.time}: ${rec.message}');
   });
   Logger.root.level = Level.INFO;
 
   Disposable.enableDebugMode();
-
-  ButtonElement createButton = querySelector('#create-button');
-  ButtonElement disposeButton = querySelector('#dispose-button');
-  InputElement childCountField = querySelector('#child-count-field');
-  InputElement treeDepthField = querySelector('#tree-depth-field');
 
   Disposable treeRoot;
 
@@ -54,12 +59,18 @@ void main() {
     controller = new StreamController.broadcast();
 
     treeRoot = createDisposableTree(treeDepth);
-    print('Disposable tree size: ${treeRoot.disposalTreeSize}');
+    addToOutput('Disposable tree size: ${treeRoot.disposalTreeSize}');
+    outputBox.scrollTo(0, outputBox.scrollHeight);
   });
 
   disposeButton.onClick.listen((_) {
+    var startTime = new DateTime.now().millisecondsSinceEpoch;
     treeRoot.dispose().then((_) {
-      print('Disposable tree size: ${treeRoot.disposalTreeSize}');
+      var endTime = new DateTime.now().millisecondsSinceEpoch;
+      var delta = endTime - startTime;
+      addToOutput('Disposable tree size: ${treeRoot.disposalTreeSize}');
+      addToOutput('Disposable took ${delta / 1000} seconds to dispose');
+      outputBox.scrollTo(0, outputBox.scrollHeight);
       treeRoot = null;
     });
   });

--- a/example/disposable/index.html
+++ b/example/disposable/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Disposable Example</title>
+    <style>
+        body {
+            font: 11pt/15pt 'segoe ui', verdana, arial;
+            margin: auto;
+            max-width: 850px;
+        }
+        
+        button {
+            padding: 6px 10px;
+        }
+
+        label {
+            display: block;
+            margin-bottom: 8px;
+        }
+    </style>
+</head>
+
+<body>
+    <h1>Disposable Example</h1>
+    <label for="tree-depth-field">
+        Tree depth (careful, remember it's exponential)
+        <input id="tree-depth-field" value="3" type="text" />
+    </label>
+    <label for="child-count-field">
+        Child count
+        <input id="child-count-field" value="5" type="text" />
+    </label>
+    <button id="create-button">Create</button>
+    <button id="dispose-button">Dispose</button>
+</body>
+
+<script type="application/dart" src="example.dart"></script>
+<script src="packages/browser/dart.js"></script>
+
+</html>

--- a/example/disposable/index.html
+++ b/example/disposable/index.html
@@ -21,13 +21,6 @@
             display: block;
             margin-bottom: 8px;
         }
-
-        textarea {
-            display: block;
-            height: 400px;
-            margin-top: 16px;
-            width: 500px;
-        }
     </style>
 </head>
 
@@ -43,8 +36,6 @@
     </label>
     <button id="create-button">Create</button>
     <button id="dispose-button">Dispose</button>
-
-    <textarea id="output-box"></textarea>
 </body>
 
 <script type="application/dart" src="example.dart"></script>

--- a/example/disposable/index.html
+++ b/example/disposable/index.html
@@ -21,6 +21,13 @@
             display: block;
             margin-bottom: 8px;
         }
+
+        textarea {
+            display: block;
+            height: 400px;
+            margin-top: 16px;
+            width: 500px;
+        }
     </style>
 </head>
 
@@ -36,6 +43,8 @@
     </label>
     <button id="create-button">Create</button>
     <button id="dispose-button">Dispose</button>
+
+    <textarea id="output-box"></textarea>
 </body>
 
 <script type="application/dart" src="example.dart"></script>

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>w_common examples</title>
+</head>
+<body>
+    <h1>w_common Examples</h1>
+    <ul>
+        <li><a href="disposable/">Disposable</a></li>
+    </ul>
+</body>
+</html>

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -252,6 +252,11 @@ class Disposable implements _Disposable, DisposableManagerV3 {
   /// Dispose of the object, cleaning up to prevent memory leaks.
   @override
   Future<Null> dispose() async {
+    int startTime;
+    if (_debugMode) {
+      startTime = new DateTime.now().millisecondsSinceEpoch;
+    }
+
     _logDispose();
 
     if (isDisposed) {
@@ -273,6 +278,12 @@ class Disposable implements _Disposable, DisposableManagerV3 {
     await onDispose();
 
     _completeDisposeFuture();
+
+    if (_debugMode) {
+      var endTime = new DateTime.now().millisecondsSinceEpoch;
+      _logger.info(
+          '$runtimeType $hashCode took ${(endTime - startTime) / 1000} seconds to dispose');
+    }
   }
 
   @mustCallSuper

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -252,9 +252,9 @@ class Disposable implements _Disposable, DisposableManagerV3 {
   /// Dispose of the object, cleaning up to prevent memory leaks.
   @override
   Future<Null> dispose() async {
-    int startTime;
+    Stopwatch stopwatch;
     if (_debugMode) {
-      startTime = new DateTime.now().millisecondsSinceEpoch;
+      stopwatch = new Stopwatch();
     }
 
     _logDispose();
@@ -280,9 +280,9 @@ class Disposable implements _Disposable, DisposableManagerV3 {
     _completeDisposeFuture();
 
     if (_debugMode) {
-      var endTime = new DateTime.now().millisecondsSinceEpoch;
+      stopwatch.stop();
       _logger.info(
-          '$runtimeType $hashCode took ${(endTime - startTime) / 1000} seconds to dispose');
+          '$runtimeType $hashCode took ${stopwatch.elapsed.inSeconds} seconds to dispose');
     }
   }
 

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -254,7 +254,7 @@ class Disposable implements _Disposable, DisposableManagerV3 {
   Future<Null> dispose() async {
     Stopwatch stopwatch;
     if (_debugMode) {
-      stopwatch = new Stopwatch();
+      stopwatch = new Stopwatch()..start();
     }
 
     _logDispose();
@@ -282,7 +282,7 @@ class Disposable implements _Disposable, DisposableManagerV3 {
     if (_debugMode) {
       stopwatch.stop();
       _logger.info(
-          '$runtimeType $hashCode took ${stopwatch.elapsed.inSeconds} seconds to dispose');
+          '$runtimeType $hashCode took ${stopwatch.elapsedMicroseconds / 1000000.0} seconds to dispose');
     }
   }
 

--- a/lib/src/disposable/disposable.dart
+++ b/lib/src/disposable/disposable.dart
@@ -192,6 +192,23 @@ class Disposable implements _Disposable, DisposableManagerV3 {
   /// A [Future] that will complete when this object has been disposed.
   Future<Null> get didDispose => _didDispose.future;
 
+  /// The total size of the disposal tree rooted at the current Disposable
+  /// instance.
+  ///
+  /// This should only be used for debugging and profiling as it can incur
+  /// a significant performance penalty if the tree is large.
+  int get disposalTreeSize {
+    int size = 1;
+    for (var disposable in _internalDisposables) {
+      if (disposable is Disposable) {
+        size += disposable.disposalTreeSize;
+      } else {
+        size++;
+      }
+    }
+    return size;
+  }
+
   /// Whether this object has been disposed.
   bool get isDisposed => _didDispose.isCompleted;
 

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -28,6 +28,32 @@ void main() {
       thing = new DisposableThing();
     });
 
+    group('disposalTreeSize', () {
+      test('should count all managed objects', () {
+        var controller = new StreamController();
+        var subscription = controller.stream.listen((_) {});
+        thing.manageStreamController(controller);
+        thing.manageStreamSubscription(subscription);
+        thing.manageDisposable(new DisposableThing());
+        thing.manageCompleter(new Completer());
+        thing.getManagedTimer(new Duration(days: 1), () {});
+        thing
+            .getManagedDelayedFuture(new Duration(days: 1), () {})
+            .catchError((_) {}); // Because we dispose prematurely.
+        thing.getManagedPeriodicTimer(new Duration(days: 1), (_) {});
+        expect(thing.disposalTreeSize, 8);
+        thing.dispose();
+      });
+
+      test('should count nested objects', () {
+        var nestedThing = new DisposableThing();
+        nestedThing.manageDisposable(new DisposableThing());
+        thing.manageDisposable(nestedThing);
+        expect(thing.disposalTreeSize, 3);
+        thing.dispose();
+      });
+    });
+
     group('getManagedDelayedFuture', () {
       test('should complete after specified duration', () async {
         var start = new DateTime.now().millisecondsSinceEpoch;

--- a/test/unit/vm/disposable_test.dart
+++ b/test/unit/vm/disposable_test.dart
@@ -42,7 +42,9 @@ void main() {
             .catchError((_) {}); // Because we dispose prematurely.
         thing.getManagedPeriodicTimer(new Duration(days: 1), (_) {});
         expect(thing.disposalTreeSize, 8);
-        thing.dispose();
+        thing.dispose().then(expectAsync1((_) {
+          expect(thing.disposalTreeSize, 1);
+        }));
       });
 
       test('should count nested objects', () {
@@ -50,7 +52,9 @@ void main() {
         nestedThing.manageDisposable(new DisposableThing());
         thing.manageDisposable(nestedThing);
         expect(thing.disposalTreeSize, 3);
-        thing.dispose();
+        thing.dispose().then(expectAsync1((_) {
+          expect(thing.disposalTreeSize, 1);
+        }));
       });
     });
 

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -24,6 +24,7 @@ Future main(List<String> args) async {
 
   config.format
     ..directories = [
+      'example/',
       'lib/',
       'test/',
       'tool/',


### PR DESCRIPTION
### Description

We'd like to add some dev tooling to help with debugging and optimization going forward.

### Changes

  * Add a getter (`disposalTreeSize`) to count the number of nodes in a given disposal tree to aid in performance testing / debugging
  * Add a "debug mode" that does some pretty verbose logging when enabled to allow the lifecycle of disposables to be tracked

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

