### PR TITLE
RAP-2091 Audit Stream Controller and Stream Subscription Cleanup

### DIFF
--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -23,7 +23,7 @@ Future main(List<String> args) async {
   config.analyze.entryPoints = ['lib/', 'test/unit/', 'tool/'];
 
   config.format
-    ..directories = [
+    ..paths = [
       'example/',
       'lib/',
       'test/',


### PR DESCRIPTION
### Description
I've audited the usage of stream controllers and stream subscriptions in w_common and determined they are all cleaned up correctly.

However, in doing this I took some heap snapshots in the disposable example and found it a little less than straightforward to determine if everything created in the example was cleaned up properly.

### Changes
Created a `TreeNode` class used to build the tree of disposables in the example. This allows you to search for `TreeNode` in the heap snapshots in Chrome and determine if the tree was cleaned up completely.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA
- [ ] CI passes
- [ ] Run the disposable example in Chrome
- [ ] Create a disposable tree
- [ ] Take a heap snapshot
- [ ] Search for `TreeNode` in the heap snapshot and confirm you find the tree
- [ ] Dispose the disposable tree
- [ ] Take a heap snapshot
- [ ] Search for `TreeNode` in the heap snapshot and confirm you find nothing

### Code Review
@Workiva/web-platform-pp 
@Workiva/rich-app-platform-pp 