### PR TITLE
WP-4583 Release w_common 1.6.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: w_common
 description: General utilities for Dart projects.
-version: 1.6.0
+version: 1.6.1
 author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://www.github.com/Workiva/w_common
 


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4585 Add comment about deprecated entry point.](https://github.com/Workiva/w_common/pull/41)
* [RAP-2123 Enable mixing in browser version of Disposable](https://github.com/Workiva/w_common/pull/42)


Requested by: @aarongeorge-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_common/compare/1.6.0...version-bump-w_common-1-6-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_common/compare/1.6.0...1.6.1