### PR TITLE
RAP-2125 Add leak flag functionality

### DIFF
--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -148,9 +148,6 @@ class Disposable implements disposable_common.Disposable {
   bool get isDisposing => _disposable.isDisposing;
 
   @override
-  String get leakFlagDescription => _disposable.leakFlagDescription;
-
-  @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) => _disposable
       .awaitBeforeDispose(future);
 
@@ -161,7 +158,7 @@ class Disposable implements disposable_common.Disposable {
   }
 
   @override
-  void flagLeak(String description) {
+  void flagLeak([String description]) {
     _disposable.flagLeak(description);
   }
 

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -148,6 +148,9 @@ class Disposable implements disposable_common.Disposable {
   bool get isDisposing => _disposable.isDisposing;
 
   @override
+  String get leakFlagDescription => _disposable.leakFlagDescription;
+
+  @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) => _disposable
       .awaitBeforeDispose(future);
 
@@ -155,6 +158,11 @@ class Disposable implements disposable_common.Disposable {
   Future<Null> dispose() {
     _disposable.onDisposeHandler = this.onDispose;
     return _disposable.dispose();
+  }
+
+  @override
+  void flagLeak(String description) {
+    _disposable.flagLeak(description);
   }
 
   @override

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -148,6 +148,9 @@ class Disposable implements disposable_common.Disposable {
   bool get isDisposing => _disposable.isDisposing;
 
   @override
+  bool get isLeakFlagSet => _disposable.isLeakFlagSet;
+
+  @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) => _disposable
       .awaitBeforeDispose(future);
 

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -157,7 +157,12 @@ class Disposable implements disposable_common.Disposable {
   @override
   Future<Null> dispose() {
     _disposable.onDisposeHandler = this.onDispose;
-    return _disposable.dispose();
+    return _disposable.dispose().then((_) {
+      // We want the description to be the runtime type of this
+      // object, not the proxy disposable, so we need to reset
+      // the leak flag here.
+      flagLeak(runtimeType.toString());
+    });
   }
 
   @override

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -300,6 +300,8 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
       _logger.info(
           '$runtimeType $hashCode took ${stopwatch.elapsedMicroseconds / 1000000.0} seconds to dispose');
     }
+
+    flagLeak(runtimeType.toString());
   }
 
   @mustCallSuper

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -228,9 +228,6 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
     return size;
   }
 
-  /// The description of the currently-set leak flag.
-  String get leakFlagDescription => _leakFlag.description;
-
   /// Whether this object has been disposed.
   bool get isDisposed => _didDispose.isCompleted;
 
@@ -301,13 +298,15 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
           '$runtimeType $hashCode took ${stopwatch.elapsedMicroseconds / 1000000.0} seconds to dispose');
     }
 
-    flagLeak(runtimeType.toString());
+    if (_debugMode) {
+      flagLeak();
+    }
   }
 
   @mustCallSuper
   @override
-  void flagLeak(String description) {
-    _leakFlag = new LeakFlag(description);
+  void flagLeak([String description]) {
+    _leakFlag = new LeakFlag(description ?? runtimeType.toString());
   }
 
   @mustCallSuper

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -301,15 +301,15 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
           '$runtimeType $hashCode took ${stopwatch.elapsedMicroseconds / 1000000.0} seconds to dispose');
     }
 
-    if (_debugMode) {
-      flagLeak();
-    }
+    flagLeak();
   }
 
   @mustCallSuper
   @override
   void flagLeak([String description]) {
-    _leakFlag = new LeakFlag(description ?? runtimeType.toString());
+    if (_debugMode) {
+      _leakFlag = new LeakFlag(description ?? runtimeType.toString());
+    }
   }
 
   @mustCallSuper

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -245,6 +245,9 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
   /// and will become `false` once the [didDispose] future completes.
   bool get isDisposing => _isDisposing;
 
+  @override
+  bool get isLeakFlagSet => _leakFlag != null;
+
   @mustCallSuper
   @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) {

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -112,6 +112,20 @@ abstract class DisposableManagerV3 implements DisposableManagerV2 {
   Completer<T> manageCompleter<T>(Completer<T> completer);
 }
 
+/// An interface that allows a class to flag potential leaks by marking
+/// itself with a particular class when it is disposed.
+abstract class LeakFlagger {
+  /// Flag the object as having been disposed in a way that allows easier
+  /// profiling.
+  ///
+  /// The leak flag is only set after disposal, so most instances found
+  /// in a heap snapshot will indicate memory leaks.
+  ///
+  /// Consumers can search a heap snapshot for the `LeakFlag` class to
+  /// see all instances of the flag.
+  void flagLeak(String description);
+}
+
 /// Exception thrown when an operation cannot be completed because the
 /// disposable object upon which it depended has been disposed.
 ///

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -115,6 +115,14 @@ abstract class DisposableManagerV3 implements DisposableManagerV2 {
 /// An interface that allows a class to flag potential leaks by marking
 /// itself with a particular class when it is disposed.
 abstract class LeakFlagger {
+  /// Whether the leak flag for this object has been set.
+  ///
+  /// The flag should only be set in debug mode. If debug mode is
+  /// on, the flag should be set at the end of the disposal process.
+  /// At this point, the object is expected to be eligible for
+  /// garbage collection.
+  bool get isLeakFlagSet;
+
   /// Flag the object as having been disposed in a way that allows easier
   /// profiling.
   ///

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -123,7 +123,7 @@ abstract class LeakFlagger {
   ///
   /// Consumers can search a heap snapshot for the `LeakFlag` class to
   /// see all instances of the flag.
-  void flagLeak(String description);
+  void flagLeak([String description]);
 }
 
 /// Exception thrown when an operation cannot be completed because the

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -344,4 +344,20 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         doesCallbackReturn: false);
     controller.close();
   });
+
+  group('flagLeak', () {
+    test('should set the leak flag when debug mode is on', () async {
+      Disposable.enableDebugMode();
+      expect(disposable.isLeakFlagSet, isFalse);
+      await disposable.dispose();
+      expect(disposable.isLeakFlagSet, isTrue);
+      Disposable.disableDebugMode();
+    });
+
+    test('should not set the leak flag when debug mode is off', () async {
+      expect(disposable.isLeakFlagSet, isFalse);
+      await disposable.dispose();
+      expect(disposable.isLeakFlagSet, isFalse);
+    });
+  });
 }

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -346,7 +346,21 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
   });
 
   group('flagLeak', () {
-    test('should set the leak flag when debug mode is on', () async {
+    test('should set the leak flag when debug mode is on', () {
+      Disposable.enableDebugMode();
+      expect(disposable.isLeakFlagSet, isFalse);
+      disposable.flagLeak();
+      expect(disposable.isLeakFlagSet, isTrue);
+      Disposable.disableDebugMode();
+    });
+
+    test('should not set the leak flag when debug mode is off', () {
+      expect(disposable.isLeakFlagSet, isFalse);
+      disposable.flagLeak();
+      expect(disposable.isLeakFlagSet, isFalse);
+    });
+
+    test('should set the leak flag on dispose when debug mode is on', () async {
       Disposable.enableDebugMode();
       expect(disposable.isLeakFlagSet, isFalse);
       await disposable.dispose();
@@ -354,7 +368,8 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       Disposable.disableDebugMode();
     });
 
-    test('should not set the leak flag when debug mode is off', () async {
+    test('should not set the leak flag on dispose when debug mode is off',
+        () async {
       expect(disposable.isLeakFlagSet, isFalse);
       await disposable.dispose();
       expect(disposable.isLeakFlagSet, isFalse);


### PR DESCRIPTION
### Description

@greglittlefield-wf suggested that if we annotated disposable objects with instances of a special class upon disposal, we would be better able to find things that were being leaked by searching for the special class in a heap snapshot. In theory, any instance that shows up is a leak (assuming the GC has run).

Here's Greg's example https://gist.github.com/greglittlefield-wf/4703ff40c98800047e279ca73df715b7

### Changes

Add a `LeakFlag` and corresponding attribute to `Disposable`.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

