### PR TITLE
RAP-2147 Fix timer factory bug

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -286,7 +286,7 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
     await Future.wait(_awaitableFutures);
     _awaitableFutures.clear();
 
-    for (var disposable in _internalDisposables.toList()) {
+    for (var disposable in _internalDisposables) {
       await disposable.dispose();
     }
     _internalDisposables.clear();
@@ -307,7 +307,7 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
   @mustCallSuper
   @override
   void flagLeak([String description]) {
-    if (_debugMode) {
+    if (_debugMode && _leakFlag != null) {
       _leakFlag = new LeakFlag(description ?? runtimeType.toString());
     }
   }
@@ -315,6 +315,8 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
   @mustCallSuper
   @override
   Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) {
+    _throwOnInvalidCall('getManagedDelayedFuture', 'duration', duration);
+    _throwOnInvalidCall('getManagedDelayedFuture', 'callback', callback);
     var completer = new Completer<T>();
     var timer =
         new _ObservableTimer(duration, () => completer.complete(callback()));
@@ -336,6 +338,8 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
   @mustCallSuper
   @override
   Timer getManagedTimer(Duration duration, void callback()) {
+    _throwOnInvalidCall('getManagedTimer', 'duration', duration);
+    _throwOnInvalidCall('getManagedTimer', 'callback', callback);
     var timer = new _ObservableTimer(duration, callback);
     _addObservableTimerDisposable(timer);
     return timer;
@@ -344,6 +348,8 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
   @mustCallSuper
   @override
   Timer getManagedPeriodicTimer(Duration duration, void callback(Timer timer)) {
+    _throwOnInvalidCall('getManagedPeriodicTimer', 'duration', duration);
+    _throwOnInvalidCall('getManagedPeriodicTimer', 'callback', callback);
     var timer = new _ObservableTimer.periodic(duration, callback);
     _addObservableTimerDisposable(timer);
     return timer;

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -307,7 +307,7 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
   @mustCallSuper
   @override
   void flagLeak([String description]) {
-    if (_debugMode && _leakFlag != null) {
+    if (_debugMode && _leakFlag == null) {
       _leakFlag = new LeakFlag(description ?? runtimeType.toString());
     }
   }

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -286,7 +286,7 @@ class Disposable implements _Disposable, DisposableManagerV3, LeakFlagger {
     await Future.wait(_awaitableFutures);
     _awaitableFutures.clear();
 
-    for (var disposable in _internalDisposables) {
+    for (var disposable in _internalDisposables.toList()) {
       await disposable.dispose();
     }
     _internalDisposables.clear();

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -60,6 +60,29 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       });
       disposable.dispose();
     });
+
+    test('should throw during disposal', () {
+      var completer = new Completer();
+      disposable.awaitBeforeDispose(completer.future);
+      disposable.dispose();
+      new Future(() {}).then((_) {
+        expect(disposable.isDisposing, isTrue);
+        expect(
+            () => disposable.getManagedDelayedFuture(
+                new Duration(seconds: 10), () => null),
+            throwsStateError);
+        completer.complete();
+      });
+    });
+
+    test('should throw after disposal', () async {
+      await disposable.dispose();
+      expect(disposable.isDisposed, isTrue);
+      expect(
+          () => disposable.getManagedDelayedFuture(
+              new Duration(seconds: 10), () => null),
+          throwsStateError);
+    });
   });
 
   group('getManagedTimer', () {
@@ -93,6 +116,29 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         timer.cancel();
         timer.cancel();
       }, returnsNormally);
+    });
+
+    test('should throw during disposal', () {
+      var completer = new Completer();
+      disposable.awaitBeforeDispose(completer.future);
+      disposable.dispose();
+      new Future(() {}).then((_) {
+        expect(disposable.isDisposing, isTrue);
+        expect(
+            () => disposable.getManagedTimer(
+                new Duration(seconds: 10), () => null),
+            throwsStateError);
+        completer.complete();
+      });
+    });
+
+    test('should throw after disposal', () async {
+      await disposable.dispose();
+      expect(disposable.isDisposed, isTrue);
+      expect(
+          () =>
+              disposable.getManagedTimer(new Duration(seconds: 10), () => null),
+          throwsStateError);
     });
   });
 
@@ -129,6 +175,29 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         timer.cancel();
         timer.cancel();
       }, returnsNormally);
+    });
+
+    test('should throw during disposal', () {
+      var completer = new Completer();
+      disposable.awaitBeforeDispose(completer.future);
+      disposable.dispose();
+      new Future(() {}).then((_) {
+        expect(disposable.isDisposing, isTrue);
+        expect(
+            () => disposable.getManagedPeriodicTimer(
+                new Duration(seconds: 10), (_) => null),
+            throwsStateError);
+        completer.complete();
+      });
+    });
+
+    test('should throw after disposal', () async {
+      await disposable.dispose();
+      expect(disposable.isDisposed, isTrue);
+      expect(
+          () => disposable.getManagedPeriodicTimer(
+              new Duration(seconds: 10), (_) => null),
+          throwsStateError);
     });
   });
 

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -61,18 +61,19 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       disposable.dispose();
     });
 
-    test('should throw during disposal', () {
+    test('should throw during disposal', () async {
       var completer = new Completer();
+      // ignore: unawaited_futures
       disposable.awaitBeforeDispose(completer.future);
+      // ignore: unawaited_futures
       disposable.dispose();
-      new Future(() {}).then((_) {
-        expect(disposable.isDisposing, isTrue);
-        expect(
-            () => disposable.getManagedDelayedFuture(
-                new Duration(seconds: 10), () => null),
-            throwsStateError);
-        completer.complete();
-      });
+      await new Future(() {});
+      expect(disposable.isDisposing, isTrue);
+      expect(
+          () => disposable.getManagedDelayedFuture(
+              new Duration(seconds: 10), () => null),
+          throwsStateError);
+      completer.complete();
     });
 
     test('should throw after disposal', () async {
@@ -118,18 +119,19 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       }, returnsNormally);
     });
 
-    test('should throw during disposal', () {
+    test('should throw during disposal', () async {
       var completer = new Completer();
+      // ignore: unawaited_futures
       disposable.awaitBeforeDispose(completer.future);
+      // ignore: unawaited_futures
       disposable.dispose();
-      new Future(() {}).then((_) {
-        expect(disposable.isDisposing, isTrue);
-        expect(
-            () => disposable.getManagedTimer(
-                new Duration(seconds: 10), () => null),
-            throwsStateError);
-        completer.complete();
-      });
+      await new Future(() {});
+      expect(disposable.isDisposing, isTrue);
+      expect(
+          () =>
+              disposable.getManagedTimer(new Duration(seconds: 10), () => null),
+          throwsStateError);
+      completer.complete();
     });
 
     test('should throw after disposal', () async {
@@ -177,18 +179,19 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       }, returnsNormally);
     });
 
-    test('should throw during disposal', () {
+    test('should throw during disposal', () async {
       var completer = new Completer();
+      // ignore: unawaited_futures
       disposable.awaitBeforeDispose(completer.future);
+      // ignore: unawaited_futures
       disposable.dispose();
-      new Future(() {}).then((_) {
-        expect(disposable.isDisposing, isTrue);
-        expect(
-            () => disposable.getManagedPeriodicTimer(
-                new Duration(seconds: 10), (_) => null),
-            throwsStateError);
-        completer.complete();
-      });
+      await new Future(() {});
+      expect(disposable.isDisposing, isTrue);
+      expect(
+          () => disposable.getManagedPeriodicTimer(
+              new Duration(seconds: 10), (_) => null),
+          throwsStateError);
+      completer.complete();
     });
 
     test('should throw after disposal', () async {


### PR DESCRIPTION
### Description

We allow the managed timer factories to be called during / after disposal but this will often (or perhaps always) result in a rather obscure exception because we attempt to add to the `_internalDisposables` list while it is being iterated.

A quick fix would have been to simply copy the list before iterating, but this could have actually resulted in memory leaks, particularly in the case of periodic timers since a new timer would have been created and then never forcibly disposed.

A better fix is to simply throw if one of those factories is called during / after disposal. This is the pattern we follow for the other management methods.

### Changes

Throw if one of the managed timer factories is invoked during or after disposal.

### Semantic Versioning

- [x] **Patch**
  - [ ] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

