### PR TITLE
RAP-2157 Return ManagedDisposer from getManagedDisposer.

### DIFF
--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -18,5 +18,7 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV2,
         DisposableManagerV3,
         DisposableManagerV4,
-        ObjectDisposedException;
+        DisposableManagerV5,
+        ObjectDisposedException,
+        SimpleDisposable;
 export 'package:w_common/src/common/disposable.dart' show Disposable, Disposer;

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -19,6 +19,6 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV3,
         DisposableManagerV4,
         DisposableManagerV5,
-        ManagedDisposer,
         ObjectDisposedException;
-export 'package:w_common/src/common/disposable.dart' show Disposable, Disposer;
+export 'package:w_common/src/common/disposable.dart'
+    show Disposable, Disposer, ManagedDisposer;

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -19,6 +19,6 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV3,
         DisposableManagerV4,
         DisposableManagerV5,
-        ObjectDisposedException,
-        SimpleDisposable;
+        ManagedDisposer,
+        ObjectDisposedException;
 export 'package:w_common/src/common/disposable.dart' show Disposable, Disposer;

--- a/lib/disposable_browser.dart
+++ b/lib/disposable_browser.dart
@@ -19,7 +19,7 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV3,
         DisposableManagerV4,
         DisposableManagerV5,
-        ManagedDisposer,
         ObjectDisposedException;
 export 'package:w_common/src/browser/disposable_browser.dart' show Disposable;
-export 'package:w_common/src/common/disposable.dart' show Disposer;
+export 'package:w_common/src/common/disposable.dart'
+    show Disposer, ManagedDisposer;

--- a/lib/disposable_browser.dart
+++ b/lib/disposable_browser.dart
@@ -19,7 +19,7 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV3,
         DisposableManagerV4,
         DisposableManagerV5,
-        ObjectDisposedException,
-        SimpleDisposable;
+        ManagedDisposer,
+        ObjectDisposedException;
 export 'package:w_common/src/browser/disposable_browser.dart' show Disposable;
 export 'package:w_common/src/common/disposable.dart' show Disposer;

--- a/lib/disposable_browser.dart
+++ b/lib/disposable_browser.dart
@@ -17,6 +17,9 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManager,
         DisposableManagerV2,
         DisposableManagerV3,
-        ObjectDisposedException;
+        DisposableManagerV4,
+        DisposableManagerV5,
+        ObjectDisposedException,
+        SimpleDisposable;
 export 'package:w_common/src/browser/disposable_browser.dart' show Disposable;
 export 'package:w_common/src/common/disposable.dart' show Disposer;

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -19,6 +19,7 @@ import 'package:meta/meta.dart';
 import 'package:w_common/func.dart';
 
 import 'package:w_common/src/common/disposable.dart' as disposable_common;
+import 'package:w_common/src/common/disposable_manager.dart';
 
 class _InnerDisposable extends disposable_common.Disposable {
   Func<Future<Null>> onDisposeHandler;
@@ -58,7 +59,7 @@ class _InnerDisposable extends disposable_common.Disposable {
 ///        }
 ///      }
 ///
-/// The [manageDisposer] helper allows you to clean up arbitrary objects
+/// The [getManagedDisposer] helper allows you to clean up arbitrary objects
 /// on dispose so that you can avoid keeping track of them yourself. To
 /// use it, simply provide a callback that returns a [Future] of any
 /// kind. For example:
@@ -68,14 +69,14 @@ class _InnerDisposable extends disposable_common.Disposable {
 ///
 ///        MyDisposable() {
 ///          var thing = new ThingThatRequiresCleanup();
-///          manageDisposer(() {
+///          getManagedDisposer(() {
 ///            thing.cleanUp();
 ///            return new Future(() {});
 ///          });
 ///        }
 ///      }
 ///
-/// Cleanup will then be automatically performed when the containing
+/// Cleanup will then be automatically performed when the parent
 /// object is disposed. If returning a future is inconvenient or
 /// otherwise undesirable, you may also return `null` explicitly.
 ///
@@ -198,14 +199,20 @@ class Disposable implements disposable_common.Disposable {
   void manageDisposable(disposable_common.Disposable disposable) =>
       _disposable.manageDisposable(disposable);
 
+  @deprecated
   @override
   void manageDisposer(disposable_common.Disposer disposer) =>
       _disposable.manageDisposer(disposer);
 
   @override
+  SimpleDisposable getManagedDisposer(disposable_common.Disposer disposer) =>
+      _disposable.getManagedDisposer(disposer);
+
+  @override
   void manageStreamController(StreamController controller) =>
       _disposable.manageStreamController(controller);
 
+  @deprecated
   @override
   void manageStreamSubscription(StreamSubscription subscription) =>
       _disposable.manageStreamSubscription(subscription);

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -19,7 +19,6 @@ import 'package:meta/meta.dart';
 import 'package:w_common/func.dart';
 
 import 'package:w_common/src/common/disposable.dart' as disposable_common;
-import 'package:w_common/src/common/disposable_manager.dart';
 
 class _InnerDisposable extends disposable_common.Disposable {
   Func<Future<Null>> onDisposeHandler;
@@ -205,7 +204,8 @@ class Disposable implements disposable_common.Disposable {
       _disposable.manageDisposer(disposer);
 
   @override
-  ManagedDisposer getManagedDisposer(disposable_common.Disposer disposer) =>
+  disposable_common.ManagedDisposer getManagedDisposer(
+          disposable_common.Disposer disposer) =>
       _disposable.getManagedDisposer(disposer);
 
   @override

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -205,7 +205,7 @@ class Disposable implements disposable_common.Disposable {
       _disposable.manageDisposer(disposer);
 
   @override
-  SimpleDisposable getManagedDisposer(disposable_common.Disposer disposer) =>
+  ManagedDisposer getManagedDisposer(disposable_common.Disposer disposer) =>
       _disposable.getManagedDisposer(disposer);
 
   @override

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -26,21 +26,17 @@ class InternalDisposable implements SimpleDisposable {
   final Completer<Null> _didDispose = new Completer<Null>();
   bool _isDisposing = false;
 
-  InternalDisposable(this._disposer);
+  InternalDisposable(Disposer disposer)
+      : _disposer = (disposer ?? () => new Future(() {}));
 
   @override
   Future<Null> dispose() {
-    if (isDisposed) {
-      return null;
-    }
-    if (_isDisposing) {
+    if (isDisposedOrDisposing) {
       return didDispose;
     }
     _isDisposing = true;
 
-    var disposeFuture = _disposer != null
-        ? (_disposer() ?? new Future(() {}))
-        : new Future(() {});
+    var disposeFuture = _disposer() ?? new Future(() {});
 
     return disposeFuture.then((_) {
       _disposer = null;

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -329,8 +329,8 @@ class Disposable implements DisposableManagerV5, LeakFlagger, SimpleDisposable {
   @mustCallSuper
   @override
   Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) {
-    _throwOnInvalidCall('getManagedDelayedFuture', 'duration', duration);
-    _throwOnInvalidCall('getManagedDelayedFuture', 'callback', callback);
+    _throwOnInvalidCall2(
+        'getManagedDelayedFuture', 'duration', 'callback', duration, callback);
     var completer = new Completer<T>();
     var timer =
         new _ObservableTimer(duration, () => completer.complete(callback()));
@@ -372,8 +372,8 @@ class Disposable implements DisposableManagerV5, LeakFlagger, SimpleDisposable {
   @mustCallSuper
   @override
   Timer getManagedTimer(Duration duration, void callback()) {
-    _throwOnInvalidCall('getManagedTimer', 'duration', duration);
-    _throwOnInvalidCall('getManagedTimer', 'callback', callback);
+    _throwOnInvalidCall2(
+        'getManagedTimer', 'duration', 'callback', duration, callback);
     var timer = new _ObservableTimer(duration, callback);
     _addObservableTimerDisposable(timer);
     return timer;
@@ -382,8 +382,8 @@ class Disposable implements DisposableManagerV5, LeakFlagger, SimpleDisposable {
   @mustCallSuper
   @override
   Timer getManagedPeriodicTimer(Duration duration, void callback(Timer timer)) {
-    _throwOnInvalidCall('getManagedPeriodicTimer', 'duration', duration);
-    _throwOnInvalidCall('getManagedPeriodicTimer', 'callback', callback);
+    _throwOnInvalidCall2(
+        'getManagedPeriodicTimer', 'duration', 'callback', duration, callback);
     var timer = new _ObservableTimer.periodic(duration, callback);
     _addObservableTimerDisposable(timer);
     return timer;

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -21,7 +21,7 @@ import 'package:w_common/src/common/disposable.dart';
 /// This interface allows consumers to exercise more control over how
 /// disposal is implemented for their classes.
 ///
-/// Deprecated: Use DisposableManagerV4 instead.
+/// Deprecated: Use [DisposableManagerV5] instead.
 @deprecated
 abstract class DisposableManager {
   /// Automatically dispose another object when this object is disposed.
@@ -32,6 +32,13 @@ abstract class DisposableManager {
   /// Automatically handle arbitrary disposals using a callback.
   ///
   /// The parameter may not be `null`.
+  ///
+  /// Deprecated: 1.7.0
+  /// To be removed: 2.0.0
+  ///
+  /// Use `getManagedDisposer` instead. One will need to update to
+  /// [DisposableManagerV5] or above for this.
+  @deprecated
   void manageDisposer(Disposer disposer);
 
   /// Automatically cancel a stream controller when this object is disposed.
@@ -51,8 +58,8 @@ abstract class DisposableManager {
   /// Deprecated: 1.7.0
   /// To be removed: 2.0.0
   ///
-  /// Use getManagedStreamSubscription instead. One will need to
-  /// update to DisposableManagerV4 for this.
+  /// Use `getManagedStreamSubscription` instead. One will need to update to
+  /// [DisposableManagerV4] or above for this.
   @deprecated
   void manageStreamSubscription(StreamSubscription subscription);
 }
@@ -65,7 +72,7 @@ abstract class DisposableManager {
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].
 ///
-/// Deprecated: Use DisposableManagerV4 instead.
+/// Deprecated: Use [DisposableManagerV5] instead.
 @deprecated
 abstract class DisposableManagerV2 implements DisposableManager {
   /// Creates a [Timer] instance that will be cancelled if active
@@ -88,7 +95,7 @@ abstract class DisposableManagerV2 implements DisposableManager {
 /// Deprecated: 1.7.0
 /// To be removed: 2.0.0
 ///
-/// Use DisposableManagerV4 instead.
+/// Use [DisposableManagerV5] instead.
 @deprecated
 abstract class DisposableManagerV3 implements DisposableManagerV2 {
   /// Add [future] to a list of futures that will be awaited before the
@@ -99,7 +106,7 @@ abstract class DisposableManagerV3 implements DisposableManagerV2 {
   /// while the request was pending, upon returning the request's callback
   /// would throw. We can avoid this by waiting on the request's future.
   ///
-  ///      class MyApi extends Object with Disposable {
+  ///      class MyDisposable extends Disposable {
   ///        MyHelper helper;
   ///
   ///        MyApi() {
@@ -141,6 +148,12 @@ abstract class DisposableManagerV3 implements DisposableManagerV2 {
 ///
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].
+///
+/// Deprecated: 1.7.0
+/// To be removed: 2.0.0
+///
+/// Use [DisposableManagerV5] instead.
+@deprecated
 abstract class DisposableManagerV4 implements DisposableManagerV3 {
   /// Returns a [StreamSubscription] which handles events from the stream using
   /// the provided [onData], [onError] and [onDone] handlers.
@@ -155,6 +168,64 @@ abstract class DisposableManagerV4 implements DisposableManagerV3 {
   StreamSubscription<T> listenToStream<T>(
       Stream<T> stream, void onData(T event),
       {Function onError, void onDone(), bool cancelOnError});
+}
+
+/// Managers for disposable members.
+///
+/// This interface allows consumers to exercise more control over how
+/// disposal is implemented for their classes.
+///
+/// When new management methods are to be added, they should be added
+/// here first, then implemented in [Disposable].
+abstract class DisposableManagerV5 implements DisposableManagerV4 {
+  /// Automatically handle arbitrary disposals using a callback.
+  ///
+  /// The passed [Disposer] will be called on disposal of the parent object (the
+  /// parent object is `MyDisposable` in the example below). A [SimpleDisposable]
+  /// is returned in case the [Disposer] should be invoked and cleaned up before
+  /// disposal of the parent object.
+  ///
+  ///      class MyDisposable extends Disposable {
+  ///        void makeRequest() {
+  ///          var request = new Request();
+  ///
+  ///          // This will ensure that cancel is called if MyDisposable is
+  ///          // disposed.
+  ///          var disposable = getManagedDisposer(request.cancel);
+  ///
+  ///          // Evict request if it has not completed within a given time
+  ///          // frame. All internal references will be cleaned up.
+  ///          getManagedTimer(new Duration(minutes: 2), disposable.dispose);
+  ///
+  ///          // ...
+  ///        }
+  ///      }
+  ///
+  /// Note: [Disposable] will store a reference to [disposer] until an explicit
+  /// `dispose` call to either the parent object, or the returned
+  /// [SimpleDisposable]. The reference to [disposer] will prevent the callback
+  /// and anything referenced in the callback from being garbage collected until
+  /// one of these two things happen. These references can be a vector for memory
+  /// leaks. For this reason it is recommended to avoid references in [disposer]
+  /// to objects not created by the parent object. These objects should be
+  /// managed by their parent. At most one would need to manage the parent using
+  /// [manageDisposable].
+  ///
+  /// Example BAD use case: `request` should not be referenced in a [Disposer]
+  /// because `MyDisposable` did not create it.
+  ///
+  ///      class MyDisposable extends Disposable {
+  ///        void addRequest(Request request) {
+  ///          // ...
+  ///
+  ///          // request comes from an external source, the reference held by
+  ///          // this clojure may introduce a memory leak.
+  ///          getManagedDisposer(request.cancel);
+  ///        }
+  ///      }
+  ///
+  /// The parameter may not be `null`.
+  SimpleDisposable getManagedDisposer(Disposer disposer);
 }
 
 /// An interface that allows a class to flag potential leaks by marking
@@ -186,3 +257,30 @@ abstract class LeakFlagger {
 /// the object managing it is disposed, the future will complete with
 /// an instance of this exception.
 class ObjectDisposedException implements Exception {}
+
+/// Used to invoke, and remove references to, a [Disposer] before disposal of the
+/// parent object.
+abstract class SimpleDisposable {
+  /// A [Future] that will complete when this object has been disposed.
+  Future<Null> get didDispose;
+
+  /// Whether this object has been disposed.
+  bool get isDisposed;
+
+  /// Whether this object has been disposed or is disposing.
+  ///
+  /// This will become `true` as soon as the [dispose] method is called
+  /// and will remain `true` forever. This is intended as a convenience
+  /// and `object.isDisposedOrDisposing` will always be the same as
+  /// `object.isDisposed || object.isDisposing`.
+  bool get isDisposedOrDisposing;
+
+  /// Whether this object is in the process of being disposed.
+  ///
+  /// This will become `true` as soon as the [dispose] method is called
+  /// and will become `false` once the [didDispose] future completes.
+  bool get isDisposing;
+
+  /// Dispose of the object, cleaning up to prevent memory leaks.
+  Future<Null> dispose();
+}

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -257,30 +257,3 @@ abstract class LeakFlagger {
 /// the object managing it is disposed, the future will complete with
 /// an instance of this exception.
 class ObjectDisposedException implements Exception {}
-
-/// Used to invoke, and remove references to, a [Disposer] before disposal of the
-/// parent object.
-abstract class ManagedDisposer {
-  /// A [Future] that will complete when this object has been disposed.
-  Future<Null> get didDispose;
-
-  /// Whether this object has been disposed.
-  bool get isDisposed;
-
-  /// Whether this object has been disposed or is disposing.
-  ///
-  /// This will become `true` as soon as the [dispose] method is called
-  /// and will remain `true` forever. This is intended as a convenience
-  /// and `object.isDisposedOrDisposing` will always be the same as
-  /// `object.isDisposed || object.isDisposing`.
-  bool get isDisposedOrDisposing;
-
-  /// Whether this object is in the process of being disposed.
-  ///
-  /// This will become `true` as soon as the [dispose] method is called
-  /// and will become `false` once the [didDispose] future completes.
-  bool get isDisposing;
-
-  /// Dispose of the object, cleaning up to prevent memory leaks.
-  Future<Null> dispose();
-}

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -181,7 +181,7 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
   /// Automatically handle arbitrary disposals using a callback.
   ///
   /// The passed [Disposer] will be called on disposal of the parent object (the
-  /// parent object is `MyDisposable` in the example below). A [SimpleDisposable]
+  /// parent object is `MyDisposable` in the example below). A [ManagedDisposer]
   /// is returned in case the [Disposer] should be invoked and cleaned up before
   /// disposal of the parent object.
   ///
@@ -203,7 +203,7 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
   ///
   /// Note: [Disposable] will store a reference to [disposer] until an explicit
   /// `dispose` call to either the parent object, or the returned
-  /// [SimpleDisposable]. The reference to [disposer] will prevent the callback
+  /// [ManagedDisposer]. The reference to [disposer] will prevent the callback
   /// and anything referenced in the callback from being garbage collected until
   /// one of these two things happen. These references can be a vector for memory
   /// leaks. For this reason it is recommended to avoid references in [disposer]
@@ -225,7 +225,7 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
   ///      }
   ///
   /// The parameter may not be `null`.
-  SimpleDisposable getManagedDisposer(Disposer disposer);
+  ManagedDisposer getManagedDisposer(Disposer disposer);
 }
 
 /// An interface that allows a class to flag potential leaks by marking
@@ -260,7 +260,7 @@ class ObjectDisposedException implements Exception {}
 
 /// Used to invoke, and remove references to, a [Disposer] before disposal of the
 /// parent object.
-abstract class SimpleDisposable {
+abstract class ManagedDisposer {
   /// A [Future] that will complete when this object has been disposed.
   Future<Null> get didDispose;
 

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,8 +1,7 @@
 project: dart
 language: dart
 
-# dart 1.19.1
-runner_image: drydock-prod.workiva.org/workiva/smithy-runner-generator:92530
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
 
 script:
   - pub get

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -49,7 +49,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     test('should throw if object is disposing', () async {
-      disposable.manageDisposer(() async {
+      disposable.getManagedDisposer(() async {
         expect(() => callback(argument, secondArgument), throwsStateError);
       });
       await disposable.dispose();
@@ -68,9 +68,8 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
   group('disposalTreeSize', () {
     test('should count all managed objects', () {
       var controller = new StreamController();
-      var subscription = controller.stream.listen((_) {});
       disposable.manageStreamController(controller);
-      disposable.manageStreamSubscription(subscription);
+      disposable.listenToStream(controller.stream, (_) {});
       disposable.manageDisposable(disposableFactory());
       disposable.manageCompleter(new Completer());
       disposable.getManagedTimer(new Duration(days: 1), () {});

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -11,8 +11,8 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
   void testManageMethod(
       String methodName, callback(dynamic argument), dynamic argument,
-      {bool doesCallbackReturn: true}) {
-    if (doesCallbackReturn) {
+      {bool doesCallbackReturnArgument: true}) {
+    if (doesCallbackReturnArgument) {
       test('should return the argument', () {
         expect(callback(argument), same(argument));
       });
@@ -387,7 +387,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         'manageDisposable',
         (argument) => disposable.manageDisposable(argument),
         disposableFactory(),
-        doesCallbackReturn: false);
+        doesCallbackReturnArgument: false);
   });
 
   group('manageDisposer', () {
@@ -407,7 +407,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
     testManageMethod('manageDisposer',
         (argument) => disposable.manageDisposer(argument), () async => null,
-        doesCallbackReturn: false);
+        doesCallbackReturnArgument: false);
   });
 
   group('manageStreamController', () {
@@ -468,7 +468,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         'manageStreamController',
         (argument) => disposable.manageStreamController(argument),
         new StreamController(),
-        doesCallbackReturn: false);
+        doesCallbackReturnArgument: false);
   });
 
   group('manageStreamSubscription', () {
@@ -489,7 +489,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         'manageStreamSubscription',
         (argument) => disposable.manageStreamSubscription(argument),
         controller.stream.listen((_) {}),
-        doesCallbackReturn: false);
+        doesCallbackReturnArgument: false);
     controller.close();
   });
 

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -137,7 +137,58 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
   });
 
-  group('getManagedStreamSubscription', () {
+  group('getManagedDisposer', () {
+    test(
+        'should call callback and accept null return value'
+        'when parent is disposed', () async {
+      disposable.getManagedDisposer(expectAsync0(() => null));
+      await disposable.dispose();
+    });
+
+    test(
+        'should call callback and accept Future return value'
+        'when parent is disposed', () async {
+      disposable.getManagedDisposer(expectAsync0(() => new Future(() {})));
+      await disposable.dispose();
+    });
+
+    test(
+        'should call callback and accept null return value'
+        'when disposed before parent', () async {
+      var simpleDisposable =
+          disposable.getManagedDisposer(expectAsync0(() => null));
+      await simpleDisposable.dispose();
+    });
+
+    test(
+        'should call callback and accept Future return value'
+        'when disposed before parent', () async {
+      var simpleDisposable =
+          disposable.getManagedDisposer(expectAsync0(() => new Future(() {})));
+      await simpleDisposable.dispose();
+    });
+
+    test('should remove references to Disposer when disposed before parent',
+        () async {
+      var previousTreeSize = disposable.disposalTreeSize;
+
+      var simpleDisposable = disposable.getManagedDisposer(() {});
+
+      expect(disposable.disposalTreeSize, equals(previousTreeSize + 1));
+
+      await simpleDisposable.dispose();
+      await new Future(() {});
+
+      expect(disposable.isDisposed, isFalse);
+      expect(disposable.disposalTreeSize, equals(previousTreeSize));
+    });
+
+    testManageMethod('getManagedDisposer',
+        (argument) => disposable.getManagedDisposer(argument), () {},
+        doesCallbackReturnArgument: false);
+  });
+
+  group('listenToStream', () {
     test('should cancel subscription when parent is disposed', () async {
       var controller = new StreamController();
       controller.onCancel = expectAsync1(([_]) {}, count: 1);


### PR DESCRIPTION
[Jira Ticket](https://jira.atl.workiva.net/browse/RAP-2157)

Problem
--------

Currently there is no way for `Disposable` to know if a `Disposer` has been short circuited, e.g. called before disposal of the object. References held in redundant disposers have been a vector for leaks in the past.

Solution
--------

If `manageDisposer` instead returned a `Disposable` that could be called by consumers when they intended the disposers functionality to be invoked, `Disposable` would know when a `Disposer` has become redundant and could therefore be removed from internal collections. To this end `SimpleDisposable` was created and a new method `getManagedDisposer`. `manageDisposer` was deprecated.

Tests
--------
Added tests for new functionality.


### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf
@todbachman-wf 
@bencampbell-wf 
@georgelesica-wf 
