### PR TITLE
RAP-2190 Add implicit logging dependency to pubspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - sh -e /etc/init.d/xvfb start
   - sleep 3
 script:
+  - pub publish --dry-run # Validate package
   - pub run dart_dev gen-test-runner --check
   - pub run dart_dev format --check
   - pub run dart_dev analyze

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dependencies:
+  logging: ^0.11.0
   meta: ^1.0.4
 
 dev_dependencies:


### PR DESCRIPTION
The CI script was added to perform a publish dry run. This will ensure
CI fails if any warnings are generated by the validation process.



### Description

A implicit dependency on the `logging` package was introduced.

### Changes

An explicit dependency on the logging package was introduced. The CI process includes performing a dry run of the publish command which validates the package. If any new implicit dependencies are introduced it will fail the CI.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

