### PR TITLE
RAP-2201 Return Future.value()

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -33,8 +33,7 @@ class ManagedDisposer implements _Disposable {
   final Completer<Null> _didDispose = new Completer<Null>();
   bool _isDisposing = false;
 
-  ManagedDisposer(Disposer disposer)
-      : _disposer = (disposer ?? () => new Future(() {}));
+  ManagedDisposer(this._disposer);
 
   /// A [Future] that will complete when this object has been disposed.
   Future<Null> get didDispose => _didDispose.future;
@@ -57,13 +56,17 @@ class ManagedDisposer implements _Disposable {
   bool get isDisposing => _isDisposing;
 
   /// Dispose of the object, cleaning up to prevent memory leaks.
+  @override
   Future<Null> dispose() {
     if (isDisposedOrDisposing) {
       return didDispose;
     }
     _isDisposing = true;
 
-    var disposeFuture = _disposer() ?? new Future(() {});
+    var disposeFuture = _disposer != null
+        ? (_disposer() ?? new Future.value())
+        : new Future.value();
+    _disposer = null;
 
     return disposeFuture.then((_) {
       _disposer = null;

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -413,8 +413,7 @@ class Disposable implements _Disposable, DisposableManagerV5, LeakFlagger {
   StreamSubscription<T> listenToStream<T>(
       Stream<T> stream, void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    _throwOnInvalidCall2(
-        'getManagedStreamSubscription', 'stream', 'onData', stream, onData);
+    _throwOnInvalidCall2('listenToStream', 'stream', 'onData', stream, onData);
     var managedStreamSubscription = new ManagedStreamSubscription(
         stream, onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -58,7 +58,7 @@ abstract class DisposableManager {
   /// Deprecated: 1.7.0
   /// To be removed: 2.0.0
   ///
-  /// Use `getManagedStreamSubscription` instead. One will need to update to
+  /// Use `listenToStream` instead. One will need to update to
   /// [DisposableManagerV4] or above for this.
   @deprecated
   void manageStreamSubscription(StreamSubscription subscription);

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -230,7 +230,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
     var controller = new StreamController();
     testManageMethod2(
-        'getManagedStreamSubscription',
+        'listenTOStream',
         (argument, secondArgument) =>
             disposable.listenToStream(argument, secondArgument),
         controller.stream,

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -230,7 +230,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
     var controller = new StreamController();
     testManageMethod2(
-        'listenTOStream',
+        'listenToStream',
         (argument, secondArgument) =>
             disposable.listenToStream(argument, secondArgument),
         controller.stream,


### PR DESCRIPTION
[Jira ticket](https://jira.atl.workiva.net/browse/RAP-2201)

### Description

`Future.value()` returns a future that is guaranteed to complete on the next event loop cycle, whereas `new Future((){})` enqueues a new future. In 1.7.0 we started returning a new enqueued future rather than a Future guaranteed to complete on the next event loop iteration. We should keep the API consistent.

### Changes

Revert to returning `Future.value()`.

### Semantic Versioning

- [x] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes
- [ ] Link into `w_table` master, unit tests should pass.

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

