### PR TITLE
RAP-2202 Return null when appropriate.

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -422,9 +422,9 @@ class Disposable implements _Disposable, DisposableManagerV5, LeakFlagger {
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
     _logManageMessage(managedStreamSubscription);
 
-    var disposable = new ManagedDisposer(() async {
+    var disposable = new ManagedDisposer(() {
       _logUnmanageMessage(managedStreamSubscription);
-      await managedStreamSubscription.cancel();
+      return managedStreamSubscription.cancel();
     });
 
     _internalDisposables.add(disposable);

--- a/lib/src/common/managed_stream_subscription.dart
+++ b/lib/src/common/managed_stream_subscription.dart
@@ -20,7 +20,19 @@ class ManagedStreamSubscription<T> implements StreamSubscription<T> {
 
   @override
   Future<Null> cancel() {
-    return (_subscription.cancel() ?? new Future(() {})).then((_) {
+    var result = _subscription.cancel();
+
+    // StreamSubscription.cancel() will return null if no cleanup was necessary.
+    // This behavior is described in the docs as "for historical reasons" so
+    // this may change in the future.
+    if (result == null) {
+      if (!_didCancel.isCompleted) {
+        _didCancel.complete();
+      }
+      return null;
+    }
+
+    return result.then((_) {
       if (!_didCancel.isCompleted) {
         _didCancel.complete();
       }

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 
+import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_common/disposable.dart';
 
@@ -47,6 +48,10 @@ class DisposeCounter extends Disposable {
     return super.dispose();
   }
 }
+
+class MockStreamSubscription extends Mock implements StreamSubscription {}
+
+class MockStream extends Mock implements Stream {}
 
 class TimerHarness {
   bool _didCancelTimer = true;


### PR DESCRIPTION
[Jira ticket](https://jira.atl.workiva.net/browse/RAP-2202)

### Description

`StreamSubscription.cancel()`, "Returns a future that is completed once the stream has finished its cleanup" in other words a synchronous future. StreamSubscription.cancel(), also, "For historical reasons, may ... return null if no cleanup was necessary." w_common currently returns a new enqueued asynchronous future if the cancel call returns null. This is incorrect and should be fixed.

### Changes

Return null when appropriate.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes
- [ ] Link into [this branch](https://github.com/Workiva/w_table/compare/master...travissanderson-wf:w_common-new-apis?expand=1) updating w_table to the new APIs, unit tests should pass.

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf
@bencampbell-wf 
@georgelesica-wf 
@todbachman-wf 
@smaifullerton-wk 
