### PR TITLE
WP-4861 Add manageAndReturnDisposable method

### DIFF
--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -191,6 +191,11 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
+  disposable_common.Disposable manageAndReturnDisposable(
+          disposable_common.Disposable disposable) =>
+      _disposable.manageAndReturnDisposable(disposable);
+
+  @override
   Completer<T> manageCompleter<T>(Completer<T> completer) => _disposable
       .manageCompleter(completer);
 

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -212,7 +212,7 @@ typedef Future<dynamic> Disposer();
 /// without explicit reference to [Disposable]. To do this, we use
 /// composition to include the [Disposable] machinery without changing
 /// the public interface of our class or polluting its lifecycle.
-class Disposable implements _Disposable, DisposableManagerV5, LeakFlagger {
+class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
   static bool _debugMode = false;
   static Logger _logger;
 
@@ -437,6 +437,15 @@ class Disposable implements _Disposable, DisposableManagerV5, LeakFlagger {
     });
 
     return managedStreamSubscription;
+  }
+
+  @mustCallSuper
+  @override
+  Disposable manageAndReturnDisposable(Disposable disposable) {
+    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
+    manageDisposable(disposable);
+
+    return disposable;
   }
 
   @mustCallSuper

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -27,6 +27,13 @@ abstract class DisposableManager {
   /// Automatically dispose another object when this object is disposed.
   ///
   /// The parameter may not be `null`.
+  ///
+  /// Deprecated: 1.8.0
+  /// To be removed: 2.0.0
+  ///
+  /// Use `manageAndReturnDisposable` instead. One will need to update
+  /// to [DisposableManagerV6] or above for this.
+  @deprecated
   void manageDisposable(Disposable disposable);
 
   /// Automatically handle arbitrary disposals using a callback.
@@ -177,6 +184,12 @@ abstract class DisposableManagerV4 implements DisposableManagerV3 {
 ///
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].
+///
+/// Deprecated: 1.8.0
+/// To be removed: 2.0.0
+///
+/// Use [DisposableManagerV6] instead.
+@deprecated
 abstract class DisposableManagerV5 implements DisposableManagerV4 {
   /// Automatically handle arbitrary disposals using a callback.
   ///
@@ -226,6 +239,40 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
   ///
   /// The parameter may not be `null`.
   ManagedDisposer getManagedDisposer(Disposer disposer);
+}
+
+/// Managers for disposable members.
+///
+/// This interface allows consumers to exercise more control over how
+/// disposal is implemented for their classes.
+///
+/// When new management methods are to be added, they should be added
+/// here first, then implemented in [Disposable].
+abstract class DisposableManagerV6 implements DisposableManagerV5 {
+  /// Automatically dispose another object when this object is disposed.
+  ///
+  /// This method is an extension to [manageDisposable] and returns the
+  /// passed in [Disposable] in addition to handling it's disposal. The
+  /// method should be used when a variable is set and should
+  /// conditionally be managed for disposal. The most common case will
+  /// be dealing with optional parameters:
+  ///
+  ///      class MyDisposable extends Disposable {
+  ///        // This object also extends disposable
+  ///        MyObject _internal;
+  ///
+  ///        MyDisposable({MyObject optional}) {
+  ///          // If optional is injected, we should not manage it.
+  ///          // If we create our own internal reference we should manage it.
+  ///          _internal = optional ??
+  ///              manageAndReturnDisposable(new MyObject());
+  ///        }
+  ///
+  ///        // ...
+  ///      }
+  ///
+  /// The parameter may not be `null`.
+  Disposable manageAndReturnDisposable(Disposable disposable);
 }
 
 /// An interface that allows a class to flag potential leaks by marking

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -149,6 +149,34 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
   });
 
+  group('manageAndReturnDisposable', () {
+    void injectDisposable({Disposable injected}) {
+      disposable.injected =
+          injected ?? disposable.manageAndReturnDisposable(disposableFactory());
+    }
+
+    test('should dispose managed disposable', () async {
+      injectDisposable();
+      await disposable.dispose();
+      expect(disposable.injected, isNotNull);
+      expect(disposable.isDisposed, isTrue);
+      expect(disposable.injected.isDisposed, isTrue);
+    });
+
+    test('should not dispose injected variable', () async {
+      injectDisposable(injected: disposableFactory());
+      await disposable.dispose();
+      expect(disposable.injected, isNotNull);
+      expect(disposable.isDisposed, isTrue);
+      expect(disposable.injected.isDisposed, isFalse);
+    });
+
+    testManageMethod(
+        'manageAndReturnDisposable',
+        (argument) => disposable.manageAndReturnDisposable(argument),
+        disposableFactory());
+  });
+
   group('getManagedDisposer', () {
     test(
         'should call callback and accept null return value'

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -22,6 +22,7 @@ import './typedefs.dart';
 
 abstract class StubDisposable implements Disposable {
   bool wasOnDisposeCalled = false;
+  Disposable injected;
 
   @override
   Future<Null> onDispose() {


### PR DESCRIPTION
### Description
Injecting dependencies into an object through named parameters has become a common, useful pattern as it allows the ability to specify these dependencies only if necessary and have a fallback that is constructed for you. 

In the case of disposables, the recommended pattern is to manage the disposable _only if_ the object creates a new instance. If a disposable gets passed into the object, the object should not manage the disposable as its lifetime might last longer. In order to accomplish this, the object must check if a dependency was passed in, and if not create one and manage it. There are several ways to accomplish this, but all involve conditional uses of `manageDisposable()` which start to add up as more dependencies are allowed: 
```dart
class MyDisposable extends Disposable {
  // This object also extends disposable
  MyObject _internal;

  MyDisposable({MyObject optional}) {
    // If optional is injected, we should not manage it.
    // If we create our own internal reference we should manage it.
    _internal = optional ?? new MyObject();
    if(optional == null) {
      manageDisposable(_internal);
    }
  }

  // ...
}
```

### Changes
Add a `getManagedDisposable` method that will manage the disposable passed in and return it back to the consumer to use further. 
```dart
class MyDisposable extends Disposable {
  // This object also extends disposable
  MyObject _internal;

  MyDisposable({MyObject optional}) {
    // If optional is injected, we should not manage it.
    // If we create our own internal reference we should manage it.
    _internal = optional ??
        getManagedDisposable(new MyObject());
  }

  // ...
}
```


### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@Workiva/web-platform-pp 
@Workiva/rich-app-platform-pp 

