### PR TITLE
RAP-2264 Allow managed timers to be canceled inside their callbacks

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -26,8 +26,8 @@ abstract class _Disposable {
   Future<Null> dispose();
 }
 
-/// Used to invoke, and remove references to, a [Disposer] before disposal of the
-/// parent object.
+/// Used to invoke, and remove references to, a [Disposer] before disposal
+/// of the parent object.
 class ManagedDisposer implements _Disposable {
   Disposer _disposer;
   final Completer<Null> _didDispose = new Completer<Null>();
@@ -86,12 +86,18 @@ class _ObservableTimer implements Timer {
   _ObservableTimer(Duration duration, void callback()) {
     _timer = new Timer(duration, () {
       callback();
-      _didConclude.complete();
+      _complete();
     });
   }
 
   _ObservableTimer.periodic(Duration duration, void callback(Timer t)) {
     _timer = new Timer.periodic(duration, callback);
+  }
+
+  void _complete() {
+    if (!_didConclude.isCompleted) {
+      _didConclude.complete();
+    }
   }
 
   /// The timer has either been completed or has been cancelled.
@@ -100,9 +106,7 @@ class _ObservableTimer implements Timer {
   @override
   void cancel() {
     _timer.cancel();
-    if (!_didConclude.isCompleted) {
-      _didConclude.complete();
-    }
+    _complete();
   }
 
   @override
@@ -200,12 +204,19 @@ typedef Future<dynamic> Disposer();
 ///        Disposable _disposable = new Disposable();
 ///
 ///        MyLifecycleThing() {
-///          _disposable.manageStreamSubscription(someStream.listen(() => null));
+///          _disposable.listenToStream(someStream, (_) => null));
 ///        }
 ///
 ///        @override
-///        void manageStreamSubscription(StreamSubscription sub) {
-///          _disposable.manageStreamSubscription(sub);
+///        StreamSubscription<T> listenToStream<T>(
+///            Stream<T> stream, void onData(T event),
+///            {Function onError, void onDone(), bool cancelOnError}) {
+///          return _disposable.listenToStream(
+///            stream, onData,
+///            onError: onError,
+///            onDone: onDone,
+///            cancelOnError: cancelOnError
+///          );
 ///        }
 ///
 ///        // ...more methods

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -368,6 +368,14 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       }, returnsNormally);
     });
 
+    test('should return a timer that can be canceled inside its callback',
+        () async {
+      timer.cancel();
+      timer = disposable.getManagedTimer(harness.duration, expectAsync0(() {
+        timer.cancel();
+      }));
+    });
+
     test('should throw during disposal', () async {
       var completer = new Completer();
       // ignore: unawaited_futures
@@ -426,6 +434,14 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         timer.cancel();
         timer.cancel();
       }, returnsNormally);
+    });
+
+    test('should return a timer that can be canceled inside its callback',
+        () async {
+      timer.cancel();
+      timer = disposable.getManagedTimer(harness.duration, expectAsync0(() {
+        timer.cancel();
+      }));
     });
 
     test('should throw during disposal', () async {


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description

XBRL reported a bug where canceling a managed timer within the timer's callback would throw. While this isn't strictly necessary as far as anyone knows, the Dart built-in timers support it, so we should as well.

See: https://github.com/Workiva/xbrl-module/pull/512/files#diff-875ec1f8d234f5969b7ff1935ddb1cf0R59

### Changes

Check the relevant future before completing it.

I also took the opportunity to update some documentation.

### Semantic Versioning

- [x] **Patch**
  - [ ] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

### FYI

@danaoredson-wf 