### PR TITLE
WP-4908 Release w_common 1.8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,40 @@
 language: dart
+sudo: required
+
 dart:
-  - stable
-with_content_shell: true
+  - 1.24.2
+
+addons:
+  apt:
+    packages:
+    - ttf-kochi-mincho
+    - ttf-kochi-gothic
+    - ttf-dejavu
+    - ttf-indic-fonts
+    - fonts-tlwg-garuda
+
 before_install:
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3
+  # Content shell needs this font. Since it has a EULA, we need to manually
+  # install it.
+  #
+  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
+  # fixed.
+  - sudo apt-get update -yq
+  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+  - sudo apt-get install msttcorefonts -qq
+
+  - mkdir -p bin
+  - export PATH="$PATH:`pwd`/bin/"
+  - ln -s `which chromium-browser` bin/google-chrome
+
+  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
+  - unzip content_shell-linux-x64-release.zip
+  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
+
+  -  export DISPLAY=:99.0
+  -  export PATH=$PATH":$PWD"
+  -  sh -e /etc/init.d/xvfb start
+
 script:
   - pub publish --dry-run # Validate package
   - pub run dart_dev gen-test-runner --check

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: w_common
 description: General utilities for Dart projects.
-version: 1.8.0
+version: 1.8.1
 author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://www.github.com/Workiva/w_common
 


### PR DESCRIPTION

Pulls Included in Release:
* [RAP-2264 Allow managed timers to be canceled inside their callbacks](https://github.com/Workiva/w_common/pull/60)


Requested by: @georgelesica-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/w_common/compare/1.8.0...version-bump-w_common-1-8-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/w_common/compare/1.8.0...1.8.1