### PR TITLE
RAP-2269 Un-manage managed stream subscriptions when the stream controller is closed

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -447,7 +447,7 @@ class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
 
     _internalDisposables.add(disposable);
 
-    managedStreamSubscription.didCancel.then((_) {
+    managedStreamSubscription.didComplete.then((_) {
       if (!isDisposedOrDisposing) {
         _logUnmanageMessage(disposable);
         _internalDisposables.remove(disposable);

--- a/lib/src/common/managed_stream_subscription.dart
+++ b/lib/src/common/managed_stream_subscription.dart
@@ -5,16 +5,31 @@ import 'dart:async';
 /// The [didCancel] future is used to provide an anchor point for removing
 /// internal references to `StreamSubscriptions` if consumers manually cancel the
 /// subscription. This class is not publicly exported.
+///
+/// There are three situations in which [didCancel] will be completed
 class ManagedStreamSubscription<T> implements StreamSubscription<T> {
+  final bool _cancelOnError;
+
   final StreamSubscription<T> _subscription;
 
   Completer<Null> _didCancel = new Completer();
 
   ManagedStreamSubscription(Stream<T> stream, void onData(T),
-      {Function onError, void onDone(), bool cancelOnError})
-      : _subscription = stream.listen(onData,
-            onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+      {void onError(error, [stackTrace]),
+      void onDone(),
+      bool cancelOnError: false})
+      : _cancelOnError = cancelOnError,
+        _subscription = stream.listen(onData, cancelOnError: cancelOnError) {
+    _wrapOnDone(onDone);
+    _wrapOnError(onError);
+  }
 
+  Future<Null> get didCancel => _didCancel.future;
+
+  @override
+  bool get isPaused => _subscription.isPaused;
+
+  // TODO: Should we complete when the resulting future completes?
   @override
   Future<E> asFuture<E>([E futureValue]) => _subscription.asFuture(futureValue);
 
@@ -26,36 +41,62 @@ class ManagedStreamSubscription<T> implements StreamSubscription<T> {
     // This behavior is described in the docs as "for historical reasons" so
     // this may change in the future.
     if (result == null) {
-      if (!_didCancel.isCompleted) {
-        _didCancel.complete();
-      }
+      _complete();
       return null;
     }
 
     return result.then((_) {
-      if (!_didCancel.isCompleted) {
-        _didCancel.complete();
-      }
+      _complete();
     });
   }
-
-  Future<Null> get didCancel => _didCancel.future;
-
-  @override
-  bool get isPaused => _subscription.isPaused;
 
   @override
   void onData(void handleData(T _)) => _subscription.onData(handleData);
 
   @override
-  void onDone(void handleDone()) => _subscription.onDone(handleDone);
+  void onDone(void handleDone()) => _wrapOnDone(handleDone);
 
   @override
-  void onError(Function handleError) => _subscription.onError(handleError);
+  void onError(Function handleError) => _wrapOnError(handleError);
 
   @override
   void pause([Future resumeSignal]) => _subscription.pause(resumeSignal);
 
   @override
   void resume() => _subscription.resume();
+
+  void _complete() {
+    if (!_didCancel.isCompleted) {
+      _didCancel.complete();
+    }
+  }
+
+  void _wrapOnDone(void handleDone()) {
+    _subscription.onDone(() {
+      if (handleDone != null) {
+        handleDone();
+      }
+
+      _complete();
+    });
+  }
+
+  void _wrapOnError(void handleError(error, [stackTrace])) {
+    _subscription.onError((error, [stackTrace]) {
+      if (handleError == null) {
+        // By default unhandled stream errors are handled by their zone
+        // error handler. In this case we *always* handle errors,
+        // but the consumer may actually want the default behavior,
+        // so in the case where the handler given to us by the consumer
+        // is null (which is the default) we take the default action.
+        Zone.current.handleUncaughtError(error, stackTrace);
+      } else {
+        handleError(error, stackTrace);
+      }
+
+      if (_cancelOnError) {
+        _complete();
+      }
+    });
+  }
 }

--- a/lib/src/common/managed_stream_subscription.dart
+++ b/lib/src/common/managed_stream_subscription.dart
@@ -36,7 +36,7 @@ class ManagedStreamSubscription<T> implements StreamSubscription<T> {
     return _subscription.asFuture(futureValue).then((value) {
       _complete();
       return value;
-    }).catchError((error, [stackTrace]) {
+    }).whenComplete(() {
       _complete();
     });
   }

--- a/lib/src/common/managed_stream_subscription.dart
+++ b/lib/src/common/managed_stream_subscription.dart
@@ -15,10 +15,8 @@ class ManagedStreamSubscription<T> implements StreamSubscription<T> {
   Completer<Null> _didCancel = new Completer();
 
   ManagedStreamSubscription(Stream<T> stream, void onData(T),
-      {void onError(error, [stackTrace]),
-      void onDone(),
-      bool cancelOnError: false})
-      : _cancelOnError = cancelOnError,
+      {void onError(error, [stackTrace]), void onDone(), bool cancelOnError})
+      : _cancelOnError = cancelOnError ?? false,
         _subscription = stream.listen(onData, cancelOnError: cancelOnError) {
     _wrapOnDone(onDone);
     _wrapOnError(onError);

--- a/lib/src/common/managed_stream_subscription.dart
+++ b/lib/src/common/managed_stream_subscription.dart
@@ -33,10 +33,7 @@ class ManagedStreamSubscription<T> implements StreamSubscription<T> {
 
   @override
   Future<E> asFuture<E>([E futureValue]) {
-    return _subscription.asFuture(futureValue).then((value) {
-      _complete();
-      return value;
-    }).whenComplete(() {
+    return _subscription.asFuture(futureValue).whenComplete(() {
       _complete();
     });
   }

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -272,12 +272,11 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     test(
         'should throw if stream completes with an error and there is no '
         'onError handler', () {
+      // ignore: close_sinks
+      var controller = new StreamController<Null>();
+      controller.addError(new Exception('intentional'));
       runZoned(() {
-        // ignore: close_sinks
-        var controller = new StreamController<Null>();
-        // ignore: cancel_subscriptions
-        var subscription = disposable.listenToStream(controller.stream, (_) {});
-        controller.addError(new Exception('intentional'));
+        disposable.listenToStream(controller.stream, (_) {});
       }, onError: expectAsync2((error, _) {
         expect(error, new isInstanceOf<Exception>());
         expect(error.toString(), 'Exception: intentional');
@@ -351,8 +350,8 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     test(
-        'should un-manage subscription when controller is closed '
-        'due to an error, when cancelOnError is true', () async {
+        'should un-manage subscription when the stream emits an error '
+        'when cancelOnError is true', () async {
       var previousTreeSize = disposable.disposalTreeSize;
 
       // ignore: close_sinks
@@ -370,8 +369,8 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     test(
-        'should not un-manage subscription when controller is closed '
-        'due to an error, even when cancelOnError is false', () async {
+        'should not un-manage subscription when the stream emits an error '
+        'when cancelOnError is false', () async {
       var previousTreeSize = disposable.disposalTreeSize;
 
       // ignore: close_sinks

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -67,8 +67,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     var nullReturningSub = new MockStreamSubscription();
 
     when(nullReturningSub.cancel()).thenReturn(null);
-    when(stream.listen(any, onDone: any, onError: any, cancelOnError: any))
-        .thenReturn(nullReturningSub);
+    when(stream.listen(any, cancelOnError: any)).thenReturn(nullReturningSub);
 
     return stream;
   }
@@ -272,12 +271,11 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     test(
-        'should return ManagedStreamSubscription that returns null when an'
+        'should return ManagedStreamSubscription that returns null when an '
         'unwrapped StreamSubscription would have', () async {
       var stream = getNullReturningSubscriptionStream();
 
-      var unwrappedSubscription = stream.listen((_) {},
-          onDone: null, onError: null, cancelOnError: false);
+      var unwrappedSubscription = stream.listen((_) {}, cancelOnError: false);
 
       expect(unwrappedSubscription.cancel(), isNull);
 
@@ -287,7 +285,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     test(
-        'should remove references when stream subscription is closed before'
+        'should remove references when stream subscription is closed before '
         'disposal when canceling a stream subscription returns null', () async {
       var previousTreeSize = disposable.disposalTreeSize;
 

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -371,7 +371,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
     test(
         'should not un-manage subscription when controller is closed '
-        'due to an error and cancelOnError is false', () async {
+        'due to an error, even when cancelOnError is false', () async {
       var previousTreeSize = disposable.disposalTreeSize;
 
       // ignore: close_sinks


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description

Managed subscriptions create through `listenToStream` do not un-manage when the corresponding stream controller is closed. We can achieve this using the `onDone`.

### Changes

Mimic the behavior of built-in stream subscriptions using `onDone`. Also, since the same thing should happen when the stream delivers an error if `cancelOnError` was true, implement this behavior as well.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes
- [ ] +1 / Review by @aaronstgeorge-wf 

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

