### PR TITLE
WP-5009 Add DDC Compliance

### DIFF
--- a/example/disposable/example.dart
+++ b/example/disposable/example.dart
@@ -7,7 +7,7 @@ import 'package:w_common/disposable.dart';
 class TreeNode extends Disposable {
   TreeNode(int depth, int childCount) {
     manageStreamController(new StreamController.broadcast());
-    manageStreamSubscription(document.onDoubleClick.listen(_onDoubleClick));
+    listenToStream(document.onDoubleClick, _onDoubleClick);
 
     if (depth > 0) {
       for (int i = 0; i < childCount; i++) {
@@ -16,7 +16,7 @@ class TreeNode extends Disposable {
     }
   }
 
-  void _onDoubleClick(MouseEvent _) {
+  void _onDoubleClick(Event _) {
     print('document double clicked');
   }
 }
@@ -49,7 +49,7 @@ void main() {
   });
 
   disposeButton.onClick.listen((_) {
-    treeRoot.dispose().then((_) {
+    treeRoot?.dispose()?.then((_) {
       print('Disposable tree size: ${treeRoot.disposalTreeSize}');
       treeRoot = null;
     });

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -272,7 +272,7 @@ class Disposable implements disposable_common.Disposable {
   void _subscribeToEvent(EventTarget eventTarget, String event,
       EventListener callback, bool useCapture) {
     eventTarget.addEventListener(event, callback, useCapture);
-    _disposable.manageDisposer(() {
+    _disposable.getManagedDisposer(() {
       eventTarget.removeEventListener(event, callback, useCapture);
     });
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,13 @@ dependencies:
 
 dev_dependencies:
   coverage: ^0.7.2
-  dart_dev: ^1.7.2
+  dart_dev: ^1.8.0
   dart_style: ^0.2.16
   dartdoc: ^0.9.0
   mockito: '>=0.8.0'
   test: ^0.12.4
+
+transformers:
+  - test/pub_serve:
+      $include: test/**_test{s*.*,}dart
+

--- a/smithy.yaml
+++ b/smithy.yaml
@@ -1,10 +1,11 @@
 project: dart
 language: dart
 
-runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 # Dart 1.24.2
+runner_image: drydock-prod.workiva.net/workiva/smithy-runner-generator:203768 # Dart 1.24.2
 
 script:
-  - pub get
+  - pub get --packages-dir
+  - xvfb-run -s '-screen 0 1024x768x24' pub run dart_dev test --pub-serve --web-compiler=dartdevc -p chrome -p vm
 
 artifacts:
   build:

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -24,7 +24,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     test('should throw if object is disposing', () async {
-      disposable.manageDisposer(() async {
+      disposable.getManagedDisposer(() async {
         expect(() => callback(argument), throwsStateError);
       });
       await disposable.dispose();
@@ -67,7 +67,10 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     var nullReturningSub = new MockStreamSubscription();
 
     when(nullReturningSub.cancel()).thenReturn(null);
-    when(stream.listen(any, onDone: any, onError: any, cancelOnError: any))
+    when(stream.listen(typed(any),
+            onDone: typed(any, named: 'onDone'),
+            onError: typed(any, named: 'onError'),
+            cancelOnError: typed(any, named: 'cancelOnError')))
         .thenReturn(nullReturningSub);
 
     return stream;
@@ -90,9 +93,9 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
           .catchError((_) {}); // Because we dispose prematurely.
       disposable.getManagedPeriodicTimer(new Duration(days: 1), (_) {});
       expect(disposable.disposalTreeSize, 8);
-      disposable.dispose().then(expectAsync1((_) {
+      return disposable.dispose().then((_) {
         expect(disposable.disposalTreeSize, 1);
-      }));
+      });
     });
 
     test('should count nested objects', () {
@@ -100,9 +103,9 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       nestedThing.manageDisposable(disposableFactory());
       disposable.manageDisposable(nestedThing);
       expect(disposable.disposalTreeSize, 3);
-      disposable.dispose().then(expectAsync1((_) {
+      return disposable.dispose().then((_) {
         expect(disposable.disposalTreeSize, 1);
-      }));
+      });
     });
   });
 
@@ -557,6 +560,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     test(
         'should call callback and accept null return value'
         'when parent is disposed', () async {
+      // ignore: deprecated_member_use
       disposable.manageDisposer(expectAsync0(() => null));
       await disposable.dispose();
     });
@@ -564,12 +568,16 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     test(
         'should call callback and accept Future return value'
         'when parent is disposed', () async {
+      // ignore: deprecated_member_use
       disposable.manageDisposer(expectAsync0(() => new Future(() {})));
       await disposable.dispose();
     });
 
-    testManageMethod('manageDisposer',
-        (argument) => disposable.manageDisposer(argument), () async => null,
+    testManageMethod(
+        'manageDisposer',
+        // ignore: deprecated_member_use
+        (argument) => disposable.manageDisposer(argument),
+        () async => null,
         doesCallbackReturnArgument: false);
   });
 
@@ -640,6 +648,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       controller.onCancel = expectAsync1(([_]) {});
       var subscription =
           controller.stream.listen(expectAsync1((_) {}, count: 0));
+      // ignore: deprecated_member_use
       disposable.manageStreamSubscription(subscription);
       await disposable.dispose();
       controller.add(null);
@@ -650,6 +659,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     var controller = new StreamController();
     testManageMethod(
         'manageStreamSubscription',
+        // ignore: deprecated_member_use
         (argument) => disposable.manageStreamSubscription(argument),
         controller.stream.listen((_) {}),
         doesCallbackReturnArgument: false);


### PR DESCRIPTION
### Description
w_common fails when running ddc tests

### Changes
Updated tests to ensure ddc compliance
Updated Smithy to run ddc tests during CI
Bonus: addressed analyzer hints

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes
- [ ] Examples run when using DDC
  - [ ] run `pub serve example --web-complier=dartdevc` and navigate to localhost:8080 in chrome
  - [ ] ensure examples run without warnings/errors

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

