### PR TITLE
WP-5032 Accept unary and binary onError callbacks

### DIFF
--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -313,6 +313,30 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       controller.addError(new Exception('intentional'));
     });
 
+    test('should accept a unary onError callback', () {
+      // ignore: close_sinks
+      var controller = new StreamController<Null>();
+      disposable.listenToStream(controller.stream, (_) {},
+          onError: expectAsync1((error) {
+        expect(error, new isInstanceOf<Exception>());
+        expect(error.toString(), 'Exception: intentional');
+      }));
+      controller.addError(new Exception('intentional'));
+    });
+
+    test('should accept a binary onError callback', () {
+      // ignore: close_sinks
+      var controller = new StreamController<Null>();
+      disposable.listenToStream(controller.stream, (_) {},
+          onError: expectAsync2((error, stackTrace) {
+        expect(error, new isInstanceOf<Exception>());
+        expect(error.toString(), 'Exception: intentional');
+        expect(stackTrace, isNotNull);
+        expect(stackTrace, new isInstanceOf<StackTrace>());
+      }));
+      controller.addError(new Exception('intentional'));
+    });
+
     test(
         'should call onDone callback when controller is closed '
         'and there was an onDone callback set by listenToStream', () {


### PR DESCRIPTION
### Description
The `ManagedStreamSubscription` class expected a binary onError callback of type `void onError(error, [stackTrace]);`, but `Stream.listen()` accepts both unary and binary onError callbacks. Passing a unary onError callback to `listenToStream` currently results in an error like so:

```
type '([Object]) => dynamic' is not a subtype of type '(dynamic, [dynamic]) => void' of 'handleError'
```

You can see this by checking out the failed tests from the first commit's build:
https://ci.webfilings.com/build/997261

### Changes
To fix this, we can take the same approach as the `dart:async` implementation of `StreamSubscription` – typing `onError` as `Function` and then checking to see whether it is unary or binary and then calling it with the appropriate arguments.

_From dart:async/stream_impl.dart \_BufferedStreamSubscription:_

```dart
Function _onError;
...
// TODO(floitsch): this dynamic should be 'void'.
if (_onError is ZoneBinaryCallback<dynamic, Object, StackTrace>) {
  ZoneBinaryCallback<dynamic, Object, StackTrace> errorCallback = _onError
      as Object/*=ZoneBinaryCallback<dynamic, Object, StackTrace>*/;
  _zone.runBinaryGuarded(errorCallback, error, stackTrace);
} else {
  _zone.runUnaryGuarded<dynamic, Object>(
      _onError as Object/*=ZoneUnaryCallback<dynamic, Object>*/, error);
}
```


### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [x] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

