### PR TITLE
WP-5391 Add "disposal imminent" step prior to disposal

### DIFF
--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -23,7 +23,7 @@ import 'package:w_common/src/common/disposable_state.dart';
 
 class _InnerDisposable extends disposable_common.Disposable {
   Func<Future<Null>> onDisposeHandler;
-  Func<Future<Null>> willDisposeHandler;
+  Func<Future<Null>> onWillDisposeHandler;
 
   @override
   Future<Null> onDispose() {
@@ -31,8 +31,8 @@ class _InnerDisposable extends disposable_common.Disposable {
   }
 
   @override
-  Future<Null> willDispose() {
-    return willDisposeHandler();
+  Future<Null> onWillDispose() {
+    return onWillDisposeHandler();
   }
 }
 
@@ -175,7 +175,7 @@ class Disposable implements disposable_common.Disposable {
   Future<Null> dispose() {
     _disposable
       ..onDisposeHandler = this.onDispose
-      ..willDisposeHandler = this.willDispose;
+      ..onWillDisposeHandler = this.onWillDispose;
     return _disposable.dispose().then((_) {
       // We want the description to be the runtime type of this
       // object, not the proxy disposable, so we need to reset
@@ -255,7 +255,7 @@ class Disposable implements disposable_common.Disposable {
   /// completes.
   @override
   @protected
-  Future<Null> willDispose() async {
+  Future<Null> onWillDispose() async {
     return null;
   }
 

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -19,7 +19,6 @@ import 'package:meta/meta.dart';
 import 'package:w_common/func.dart';
 
 import 'package:w_common/src/common/disposable.dart' as disposable_common;
-import 'package:w_common/src/common/disposable_state.dart';
 
 class _InnerDisposable extends disposable_common.Disposable {
   Func<Future<Null>> onDisposeHandler;
@@ -161,11 +160,6 @@ class Disposable implements disposable_common.Disposable {
 
   @override
   bool get isOrWillBeDisposed => _disposable.isOrWillBeDisposed;
-
-  @override
-  @protected
-  @visibleForTesting
-  DisposableState get state => _disposable.state;
 
   @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) =>

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -387,7 +387,7 @@ class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
 
     _state = DisposableState.awaitingDisposal;
 
-    await willDispose();
+    await onWillDispose();
 
     while (_awaitableFutures.isNotEmpty) {
       final futures = _awaitableFutures.toList();
@@ -646,7 +646,7 @@ class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
   /// Disposal will _not_ start before the [Future] returned from this method
   /// completes.
   @protected
-  Future<Null> willDispose() async {
+  Future<Null> onWillDispose() async {
     return null;
   }
 

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -347,10 +347,6 @@ class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
       _state == DisposableState.disposing ||
       _state == DisposableState.disposed;
 
-  @protected
-  @visibleForTesting
-  DisposableState get state => _state;
-
   @mustCallSuper
   @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) {

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -248,10 +248,11 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
 ///
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].
+// ignore: deprecated_member_use
 abstract class DisposableManagerV6 implements DisposableManagerV5 {
   /// Automatically dispose another object when this object is disposed.
   ///
-  /// This method is an extension to [manageDisposable] and returns the
+  /// This method is an extension to `manageDisposable` and returns the
   /// passed in [Disposable] in addition to handling it's disposal. The
   /// method should be used when a variable is set and should
   /// conditionally be managed for disposal. The most common case will

--- a/lib/src/common/disposable_state.dart
+++ b/lib/src/common/disposable_state.dart
@@ -1,0 +1,7 @@
+/// Lifecycle states of a Disposable instance.
+enum DisposableState {
+  initialized,
+  awaitingDisposal,
+  disposing,
+  disposed,
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,8 @@ dependencies:
 dev_dependencies:
   coverage: ^0.7.2
   dart_dev: ^1.8.0
-  dart_style: ^0.2.16
-  dartdoc: ^0.9.0
+  dart_style: ^1.0.8
+  dartdoc: ^0.13.0
   mockito: '>=0.8.0'
   test: ^0.12.4
 

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -760,18 +760,18 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
   });
 
-  group('willDispose', () {
+  group('onWillDispose', () {
     test('should be called immediately when dispose() is called', () async {
-      expect(disposable.wasWillDisposeCalled, isFalse);
+      expect(disposable.wasOnWillDisposeCalled, isFalse);
       var completer = new Completer();
       // ignore: unawaited_futures
       disposable.awaitBeforeDispose(completer.future);
       var future = disposable.dispose();
       await new Future(() {});
-      expect(disposable.wasWillDisposeCalled, isTrue);
+      expect(disposable.wasOnWillDisposeCalled, isTrue);
       completer.complete();
       await future;
-      expect(disposable.wasWillDisposeCalled, isTrue);
+      expect(disposable.wasOnWillDisposeCalled, isTrue);
     });
   });
 

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -18,17 +18,14 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_common/disposable.dart';
 
-import 'package:w_common/src/common/disposable_state.dart';
-
 import './typedefs.dart';
 
 abstract class StubDisposable implements Disposable {
   Disposable injected;
+  int numTimesOnDisposeCalled = 0;
+  int numTimesOnWillDisposeCalled = 0;
   bool wasOnDisposeCalled = false;
   bool wasOnWillDisposeCalled = false;
-
-  @override
-  DisposableState get state;
 
   @override
   Future<Null> onDispose() {
@@ -38,6 +35,7 @@ abstract class StubDisposable implements Disposable {
     // ignore: deprecated_member_use
     expect(isDisposedOrDisposing, isTrue);
     expect(isOrWillBeDisposed, isTrue);
+    numTimesOnDisposeCalled++;
     wasOnDisposeCalled = true;
     var future = new Future<Null>(() => null);
     future.then((_) async {
@@ -60,6 +58,7 @@ abstract class StubDisposable implements Disposable {
     // ignore: deprecated_member_use
     expect(isDisposedOrDisposing, isFalse);
     expect(isOrWillBeDisposed, isTrue);
+    numTimesOnWillDisposeCalled++;
     wasOnWillDisposeCalled = true;
     return new Future(() {});
   }

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -18,26 +18,50 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 import 'package:w_common/disposable.dart';
 
+import 'package:w_common/src/common/disposable_state.dart';
+
 import './typedefs.dart';
 
 abstract class StubDisposable implements Disposable {
-  bool wasOnDisposeCalled = false;
   Disposable injected;
+  bool wasOnDisposeCalled = false;
+  bool wasWillDisposeCalled = false;
+
+  @override
+  DisposableState get state;
 
   @override
   Future<Null> onDispose() {
     expect(isDisposed, isFalse);
+    // ignore: deprecated_member_use
     expect(isDisposing, isTrue);
+    // ignore: deprecated_member_use
     expect(isDisposedOrDisposing, isTrue);
+    expect(isOrWillBeDisposed, isTrue);
     wasOnDisposeCalled = true;
     var future = new Future<Null>(() => null);
     future.then((_) async {
       await new Future(() {}); // Give it a chance to update state.
       expect(isDisposed, isTrue);
+      // ignore: deprecated_member_use
       expect(isDisposing, isFalse);
+      // ignore: deprecated_member_use
       expect(isDisposedOrDisposing, isTrue);
+      expect(isOrWillBeDisposed, isTrue);
     });
     return future;
+  }
+
+  @override
+  Future<Null> willDispose() {
+    expect(isDisposed, isFalse);
+    // ignore: deprecated_member_use
+    expect(isDisposing, isFalse);
+    // ignore: deprecated_member_use
+    expect(isDisposedOrDisposing, isFalse);
+    expect(isOrWillBeDisposed, isTrue);
+    wasWillDisposeCalled = true;
+    return new Future(() {});
   }
 }
 

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -25,7 +25,7 @@ import './typedefs.dart';
 abstract class StubDisposable implements Disposable {
   Disposable injected;
   bool wasOnDisposeCalled = false;
-  bool wasWillDisposeCalled = false;
+  bool wasOnWillDisposeCalled = false;
 
   @override
   DisposableState get state;
@@ -53,14 +53,14 @@ abstract class StubDisposable implements Disposable {
   }
 
   @override
-  Future<Null> willDispose() {
+  Future<Null> onWillDispose() {
     expect(isDisposed, isFalse);
     // ignore: deprecated_member_use
     expect(isDisposing, isFalse);
     // ignore: deprecated_member_use
     expect(isDisposedOrDisposing, isFalse);
     expect(isOrWillBeDisposed, isTrue);
-    wasWillDisposeCalled = true;
+    wasOnWillDisposeCalled = true;
     return new Future(() {});
   }
 }


### PR DESCRIPTION
### Description

There are 2 issues being addressed here:

1. The existing logic around awaitable futures (futures registered via `awaitBeforeDispose`) only waits for the set of futures available when `dispose()` is called – but ignores additional futures registered between calling `dispose()` and when all other awaitable futures have completed.
1. Currently, `isDisposing=true` as soon as `dispose()` is called. However, actual disposal doesn't begin until after the awaitable futures complete. This means that the `Disposable` API is unusable sooner than it needs to be because they check for `isDisposingOrDisposed`.

### Changes

- Use a `while` loop to continuously wait for registered futures until there are no more.
- Switch to an internal enum to manage the state of the Disposable instance
- Add a `Future<Null> willDispose();` lifecycle hook that can be implemented by extenders of `Disposable` – this hook gets called as soon as `dispose()` is called but before disposal actually begins. Potential use cases are to allow instances to cancel pending async tasks, do some cleanup, or kick start some actions that result in awaited futures completing so that disposal can actually occur.
- Add an "awaiting disposal" state that is entered as soon as `dispose()` is called. In this state, all of the `Disposable` APIs are still usable and it is perfectly valid to continue processing async tasks. The "disposing" state is not entered until `willDispose()` and all futures registered via `awaitBeforeDispose()` complete.
- Add an `bool isOrWillBeDisposed` getter that is `true` as soon as `dispose()` is called and remains true forever.
- Deprecate the other bool getters, as `isOrWillBeDisposed` should be sufficient for public consumers. All they really need to know is if disposal has been requested.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

