### PR TITLE
WP-5487 Make manageAndReturnDisposable generic

### DIFF
--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -24,7 +24,9 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV4,
         // ignore: deprecated_member_use
         DisposableManagerV5,
+        // ignore: deprecated_member_use
         DisposableManagerV6,
+        DisposableManagerV7,
         ObjectDisposedException;
 export 'package:w_common/src/common/disposable.dart'
     show Disposable, Disposer, ManagedDisposer;

--- a/lib/disposable_browser.dart
+++ b/lib/disposable_browser.dart
@@ -24,7 +24,9 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV4,
         // ignore: deprecated_member_use
         DisposableManagerV5,
+        // ignore: deprecated_member_use
         DisposableManagerV6,
+        DisposableManagerV7,
         ObjectDisposedException;
 export 'package:w_common/src/browser/disposable_browser.dart' show Disposable;
 export 'package:w_common/src/common/disposable.dart'

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -204,9 +204,14 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
-  T manageAndReturnDisposable<T extends disposable_common.Disposable>(
-          T disposable) =>
+  disposable_common.Disposable manageAndReturnDisposable(
+          disposable_common.Disposable disposable) =>
       _disposable.manageAndReturnDisposable(disposable);
+
+  @override
+  T manageAndReturnTypedDisposable<T extends disposable_common.Disposable>(
+          T disposable) =>
+      _disposable.manageAndReturnTypedDisposable(disposable);
 
   @override
   Completer<T> manageCompleter<T>(Completer<T> completer) =>

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -204,8 +204,8 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
-  disposable_common.Disposable manageAndReturnDisposable(
-          disposable_common.Disposable disposable) =>
+  T manageAndReturnDisposable<T extends disposable_common.Disposable>(
+          T disposable) =>
       _disposable.manageAndReturnDisposable(disposable);
 
   @override

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -231,7 +231,7 @@ typedef Future<dynamic> Disposer();
 /// without explicit reference to [Disposable]. To do this, we use
 /// composition to include the [Disposable] machinery without changing
 /// the public interface of our class or polluting its lifecycle.
-class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
+class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   static bool _debugMode = false;
   static Logger _logger;
 
@@ -520,7 +520,16 @@ class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
 
   @mustCallSuper
   @override
-  T manageAndReturnDisposable<T extends Disposable>(T disposable) {
+  Disposable manageAndReturnDisposable(Disposable disposable) {
+    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
+    manageDisposable(disposable);
+
+    return disposable;
+  }
+
+  @mustCallSuper
+  @override
+  T manageAndReturnTypedDisposable<T extends Disposable>(T disposable) {
     _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -520,7 +520,7 @@ class Disposable implements _Disposable, DisposableManagerV6, LeakFlagger {
 
   @mustCallSuper
   @override
-  Disposable manageAndReturnDisposable(Disposable disposable) {
+  T manageAndReturnDisposable<T extends Disposable>(T disposable) {
     _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -21,7 +21,7 @@ import 'package:w_common/src/common/disposable.dart';
 /// This interface allows consumers to exercise more control over how
 /// disposal is implemented for their classes.
 ///
-/// Deprecated: Use [DisposableManagerV5] instead.
+/// Deprecated: Use [DisposableManagerV7] instead.
 @deprecated
 abstract class DisposableManager {
   /// Automatically dispose another object when this object is disposed.
@@ -79,7 +79,7 @@ abstract class DisposableManager {
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].
 ///
-/// Deprecated: Use [DisposableManagerV5] instead.
+/// Deprecated: Use [DisposableManagerV7] instead.
 @deprecated
 abstract class DisposableManagerV2 implements DisposableManager {
   /// Creates a [Timer] instance that will be cancelled if active
@@ -102,7 +102,7 @@ abstract class DisposableManagerV2 implements DisposableManager {
 /// Deprecated: 1.7.0
 /// To be removed: 2.0.0
 ///
-/// Use [DisposableManagerV5] instead.
+/// Use [DisposableManagerV7] instead.
 @deprecated
 abstract class DisposableManagerV3 implements DisposableManagerV2 {
   /// Add [future] to a list of futures that will be awaited before the
@@ -159,7 +159,7 @@ abstract class DisposableManagerV3 implements DisposableManagerV2 {
 /// Deprecated: 1.7.0
 /// To be removed: 2.0.0
 ///
-/// Use [DisposableManagerV5] instead.
+/// Use [DisposableManagerV7] instead.
 @deprecated
 abstract class DisposableManagerV4 implements DisposableManagerV3 {
   /// Returns a [StreamSubscription] which handles events from the stream using
@@ -188,7 +188,7 @@ abstract class DisposableManagerV4 implements DisposableManagerV3 {
 /// Deprecated: 1.8.0
 /// To be removed: 2.0.0
 ///
-/// Use [DisposableManagerV6] instead.
+/// Use [DisposableManagerV7] instead.
 @deprecated
 abstract class DisposableManagerV5 implements DisposableManagerV4 {
   /// Automatically handle arbitrary disposals using a callback.
@@ -252,7 +252,7 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
 /// Deprecated: 1.10.0
 /// To be removed: 2.0.0
 ///
-/// Use [DisposableManagerV6] instead.
+/// Use [DisposableManagerV7] instead.
 @deprecated
 abstract class DisposableManagerV6 implements DisposableManagerV5 {
   /// Automatically dispose another object when this object is disposed.

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -31,8 +31,8 @@ abstract class DisposableManager {
   /// Deprecated: 1.8.0
   /// To be removed: 2.0.0
   ///
-  /// Use `manageAndReturnDisposable` instead. One will need to update
-  /// to [DisposableManagerV6] or above for this.
+  /// Use `manageAndReturnTypedDisposable` instead. One will need to update
+  /// to [DisposableManagerV7] or above for this.
   @deprecated
   void manageDisposable(Disposable disposable);
 
@@ -248,7 +248,12 @@ abstract class DisposableManagerV5 implements DisposableManagerV4 {
 ///
 /// When new management methods are to be added, they should be added
 /// here first, then implemented in [Disposable].
-// ignore: deprecated_member_use
+///
+/// Deprecated: 1.10.0
+/// To be removed: 2.0.0
+///
+/// Use [DisposableManagerV6] instead.
+@deprecated
 abstract class DisposableManagerV6 implements DisposableManagerV5 {
   /// Automatically dispose another object when this object is disposed.
   ///
@@ -273,7 +278,46 @@ abstract class DisposableManagerV6 implements DisposableManagerV5 {
   ///      }
   ///
   /// The parameter may not be `null`.
-  T manageAndReturnDisposable<T extends Disposable>(T disposable);
+  ///
+  /// Use `manageAndReturnTypedDisposable` instead. One will need to update
+  /// to [DisposableManagerV7] or above for this.
+  @deprecated
+  Disposable manageAndReturnDisposable(Disposable disposable);
+}
+
+/// Managers for disposable members.
+///
+/// This interface allows consumers to exercise more control over how
+/// disposal is implemented for their classes.
+///
+/// When new management methods are to be added, they should be added
+/// here first, then implemented in [Disposable].
+// ignore: deprecated_member_use
+abstract class DisposableManagerV7 implements DisposableManagerV6 {
+  /// Automatically dispose another object when this object is disposed.
+  ///
+  /// This method is an extension to `manageAndReturnDisposable` and returns the
+  /// passed in [Disposable] as its original type in addition to handling its
+  /// disposal. The method should be used when a variable is set and should
+  /// conditionally be managed for disposal. The most common case will be dealing
+  /// with optional parameters:
+  ///
+  ///      class MyDisposable extends Disposable {
+  ///        // This object also extends disposable
+  ///        MyObject _internal;
+  ///
+  ///        MyDisposable({MyObject optional}) {
+  ///          // If optional is injected, we should not manage it.
+  ///          // If we create our own internal reference we should manage it.
+  ///          _internal = optional ??
+  ///              manageAndReturnTypedDisposable(new MyObject());
+  ///        }
+  ///
+  ///        // ...
+  ///      }
+  ///
+  /// The parameter may not be `null`.
+  T manageAndReturnTypedDisposable<T extends Disposable>(T disposable);
 }
 
 /// An interface that allows a class to flag potential leaks by marking

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -253,7 +253,7 @@ abstract class DisposableManagerV6 implements DisposableManagerV5 {
   /// Automatically dispose another object when this object is disposed.
   ///
   /// This method is an extension to `manageDisposable` and returns the
-  /// passed in [Disposable] in addition to handling it's disposal. The
+  /// passed in [Disposable] in addition to handling its disposal. The
   /// method should be used when a variable is set and should
   /// conditionally be managed for disposal. The most common case will
   /// be dealing with optional parameters:
@@ -273,7 +273,7 @@ abstract class DisposableManagerV6 implements DisposableManagerV5 {
   ///      }
   ///
   /// The parameter may not be `null`.
-  Disposable manageAndReturnDisposable(Disposable disposable);
+  T manageAndReturnDisposable<T extends Disposable>(T disposable);
 }
 
 /// An interface that allows a class to flag potential leaks by marking

--- a/lib/src/common/managed_stream_subscription.dart
+++ b/lib/src/common/managed_stream_subscription.dart
@@ -18,7 +18,7 @@ class ManagedStreamSubscription<T> implements StreamSubscription<T> {
 
   Completer<Null> _didComplete = new Completer();
 
-  ManagedStreamSubscription(Stream<T> stream, void onData(T),
+  ManagedStreamSubscription(Stream<T> stream, void onData(T arg),
       {Function onError, void onDone(), bool cancelOnError})
       : _cancelOnError = cancelOnError ?? false,
         _subscription = stream.listen(onData, cancelOnError: cancelOnError) {

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -240,7 +240,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
     testManageMethod(
         'manageAndReturnDisposable',
-        (argument) => disposable.manageAndReturnDisposable(argument),
+        (Disposable argument) => disposable.manageAndReturnDisposable(argument),
         disposableFactory());
   });
 

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -10,8 +10,8 @@ import 'stubs.dart';
 void testCommonDisposable(Func<StubDisposable> disposableFactory) {
   StubDisposable disposable;
 
-  void testManageMethod(
-      String methodName, callback(dynamic argument), dynamic argument,
+  void testManageMethod<T>(
+      String methodName, T callback(T argument), T argument,
       {bool doesCallbackReturnArgument: true}) {
     if (doesCallbackReturnArgument) {
       test('should return the argument', () {
@@ -241,6 +241,35 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     testManageMethod(
         'manageAndReturnDisposable',
         (Disposable argument) => disposable.manageAndReturnDisposable(argument),
+        disposableFactory());
+  });
+
+  group('manageAndReturnTypedDisposable', () {
+    void injectDisposable({Disposable injected}) {
+      disposable.injected = injected ??
+          disposable.manageAndReturnTypedDisposable(disposableFactory());
+    }
+
+    test('should dispose managed disposable', () async {
+      injectDisposable();
+      await disposable.dispose();
+      expect(disposable.injected, isNotNull);
+      expect(disposable.isDisposed, isTrue);
+      expect(disposable.injected.isDisposed, isTrue);
+    });
+
+    test('should not dispose injected variable', () async {
+      injectDisposable(injected: disposableFactory());
+      await disposable.dispose();
+      expect(disposable.injected, isNotNull);
+      expect(disposable.isDisposed, isTrue);
+      expect(disposable.injected.isDisposed, isFalse);
+    });
+
+    testManageMethod(
+        'manageAndReturnTypedDisposable',
+        (StubDisposable argument) =>
+            disposable.manageAndReturnTypedDisposable(argument),
         disposableFactory());
   });
 
@@ -884,11 +913,10 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       expect(disposeCounter.disposeCount, 1);
     });
 
-    testManageMethod(
-        'manageDisposable',
-        (argument) => disposable.manageDisposable(argument),
-        disposableFactory(),
-        doesCallbackReturnArgument: false);
+    testManageMethod('manageDisposable', (argument) {
+      disposable.manageDisposable(argument);
+      return argument;
+    }, disposableFactory(), doesCallbackReturnArgument: false);
   });
 
   group('manageDisposer', () {
@@ -908,12 +936,11 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       await disposable.dispose();
     });
 
-    testManageMethod(
-        'manageDisposer',
-        // ignore: deprecated_member_use
-        (argument) => disposable.manageDisposer(argument),
-        () async => null,
-        doesCallbackReturnArgument: false);
+    testManageMethod('manageDisposer', (argument) {
+      // ignore: deprecated_member_use
+      disposable.manageDisposer(argument);
+      return argument;
+    }, () async => null, doesCallbackReturnArgument: false);
   });
 
   group('manageStreamController', () {
@@ -970,11 +997,10 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       expect(controller.isClosed, isTrue);
     });
 
-    testManageMethod(
-        'manageStreamController',
-        (argument) => disposable.manageStreamController(argument),
-        new StreamController(),
-        doesCallbackReturnArgument: false);
+    testManageMethod('manageStreamController', (argument) {
+      disposable.manageStreamController(argument);
+      return argument;
+    }, new StreamController(), doesCallbackReturnArgument: false);
   });
 
   group('manageStreamSubscription', () {
@@ -992,12 +1018,11 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
     });
 
     var controller = new StreamController();
-    testManageMethod(
-        'manageStreamSubscription',
-        // ignore: deprecated_member_use
-        (argument) => disposable.manageStreamSubscription(argument),
-        controller.stream.listen((_) {}),
-        doesCallbackReturnArgument: false);
+    testManageMethod('manageStreamSubscription', (argument) {
+      // ignore: deprecated_member_use
+      disposable.manageStreamSubscription(argument);
+      return argument;
+    }, controller.stream.listen((_) {}), doesCallbackReturnArgument: false);
     controller.close();
   });
 


### PR DESCRIPTION
### Description

The `manageAndReturnDisposable` function should have been generic so that its return value was useful as the same type as its argument. For example, it should be type-safe to do the following:

```dart
MyThing thing = new MyThing();
thing = manageAndReturnDisposable(thing);
```

### Changes

Add a method `manageAndReturnDisposable<T extends Disposable>(T disposable);`.

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

