### PR TITLE
WP-5742 w_common should follow new logger name standard

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -251,7 +251,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   static void enableDebugMode() {
     if (!_debugMode) {
       _debugMode = true;
-      _logger = new Logger('Disposable');
+      _logger = new Logger('w_common.Disposable');
     }
   }
 


### PR DESCRIPTION
### Description
<!--
Note whether this is a bug fix, improvement, feature, or tech-debt and explain
the motivation behind this PR.
-->
Rename loggers to follow the pattern: `<package_name>.<class_name>` per @leerobinson-wf's email to wf-dev.


### Testing/QA

<!-- Include additional steps for testing if necessary. -->
- [ ] CI passes


### Code Review
@Workiva/app-frameworks 