### PR TITLE
Add listenToStreamWithoutPayload

### DIFF
--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -212,6 +212,13 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
+  StreamSubscription<T> listenToStreamWithoutPayload<T>(
+          Stream<T> stream, void onData(),
+          {Function onError, void onDone(), bool cancelOnError}) =>
+      _disposable.listenToStreamWithoutPayload(stream, onData,
+          onError: onError, onDone: onDone, cancelOnError: cancelOnError);
+
+  @override
   disposable_common.Disposable manageAndReturnDisposable(
           disposable_common.Disposable disposable) =>
       _disposable.manageAndReturnDisposable(disposable);

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -232,7 +232,7 @@ typedef Future<dynamic> Disposer();
 /// without explicit reference to [Disposable]. To do this, we use
 /// composition to include the [Disposable] machinery without changing
 /// the public interface of our class or polluting its lifecycle.
-class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
+class Disposable implements _Disposable, DisposableManagerV8, LeakFlagger {
   static bool _debugMode = false;
   static Logger _logger;
 
@@ -517,6 +517,14 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     });
 
     return managedStreamSubscription;
+  }
+
+  @override
+  StreamSubscription<T> listenToStreamWithoutPayload<T>(
+      Stream<T> stream, void onData(),
+      {Function onError, void onDone(), bool cancelOnError}) {
+    return listenToStream(stream, (dynamic _) => onData(),
+        onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
   @mustCallSuper

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -320,6 +320,32 @@ abstract class DisposableManagerV7 implements DisposableManagerV6 {
   T manageAndReturnTypedDisposable<T extends Disposable>(T disposable);
 }
 
+/// Managers for disposable members.
+///
+/// This interface allows consumers to exercise more control over how
+/// disposal is implemented for their classes.
+///
+/// When new management methods are to be added, they should be added
+/// here first, then implemented in [Disposable].
+// ignore: deprecated_member_use
+abstract class DisposableManagerV8 implements DisposableManagerV7 {
+  /// Returns a [StreamSubscription] which handles events from the stream using
+  /// the provided [onData], [onError] and [onDone] handlers in the case
+  /// where the actual [onData] callback provided doesn't need the stream
+  /// payload.
+  ///
+  /// Consult documentation for Stream.listen for more info.
+  ///
+  /// If the returned `StreamSubscription` is cancelled manually (i.e. canceled
+  /// before disposal of the parent object) [Disposable] will clean up the
+  /// internal reference allowing the subscription to be garbage collected.
+  ///
+  /// Neither parameter may be `null`.
+  StreamSubscription<T> listenToStreamWithoutPayload<T>(
+      Stream<T> stream, void onData(),
+      {Function onError, void onDone(), bool cancelOnError});
+}
+
 /// An interface that allows a class to flag potential leaks by marking
 /// itself with a particular class when it is disposed.
 abstract class LeakFlagger {


### PR DESCRIPTION
### Description

People don't like having to use underscores to listen to streams when they don't care about the payload.

### Changes

Add `listenToStreamWithoutPayload` method to `Disposable`, which acts exactly like `listenToStream` but its `onData` callback doesn't have a parameter.

FYI: @travissanderson-wf @brianneal-wf 

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

