### PR TITLE
WP-6173 Fixes for Dart2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Files and directories created by pub
 .packages
-.pub/
+.pub
+.dart_tool
 build/
 packages
 # Remove the following pattern if you wish to check in your lock file

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: dart
 sudo: required
 
 dart:
-  - 1.24.2
-
+  - 1.24.3
+  - 2.0.0-dev.32.0
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 
 dart:
   - 1.24.3
-  - 2.0.0-dev.32.0
+  - stable
+  - dev
 addons:
   apt:
     packages:

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -115,10 +115,10 @@ class _ObservableTimer implements Timer {
 
   @override
   int get tick {
-      // TODO: Once fully transitioned to Dart 2 just return
-      // the tick value from our internal timer
-      // return _timer.tick;
-      throw new UnsupportedError('Timer.tick is unsupported');
+    // TODO: Once fully transitioned to Dart 2 just return
+    // the tick value from our internal timer
+    // return _timer.tick;
+    throw new UnsupportedError('Timer.tick is unsupported');
   }
 }
 

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -112,6 +112,12 @@ class _ObservableTimer implements Timer {
 
   @override
   bool get isActive => _timer.isActive;
+
+  @override
+  int get tick => _timer.tick; // Dart2 only
+  //int get tick => 0; // Works for Dart1 & 2, but will this break something about timers?
+  // can we re-implement the tick value correctly? Should we inject our own zone handler for
+  // timer creation to call the complete method?
 }
 
 /// A class used as a marker for potential memory leaks.

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -114,10 +114,12 @@ class _ObservableTimer implements Timer {
   bool get isActive => _timer.isActive;
 
   @override
-  int get tick => _timer.tick; // Dart2 only
-  //int get tick => 0; // Works for Dart1 & 2, but will this break something about timers?
-  // can we re-implement the tick value correctly? Should we inject our own zone handler for
-  // timer creation to call the complete method?
+  int get tick {
+      // TODO: Once fully transitioned to Dart 2 just return
+      // the tick value from our internal timer
+      // return _timer.tick;
+      throw new UnsupportedError('Timer.tick is unsupported');
+  }
 }
 
 /// A class used as a marker for potential memory leaks.


### PR DESCRIPTION
## Dart 2 (dev channel) Problems
 - There's a missing implementation of the `tick` method for `_ObservableTimer`. 
```
w_common git:(master) ✗ dda

::: dartanalyzer --fatal-warnings --strong lib/disposable.dart lib/invalidation_mixin.dart lib/cache.dart lib/disposable_browser.dart lib/func.dart lib/json_serializable.dart lib/w_common.dart test/unit/typedefs.dart test/unit/stubs.dart test/unit/disposable_common.dart tool/dev.dart
    Analyzing lib/disposable.dart, lib/invalidation_mixin.dart, lib/cache.dart, lib/disposable_browser.dart, lib/func.dart, lib/json_serializable.dart, lib/w_common.dart, test/unit/typedefs.dart, test/unit/stubs.dart, test/unit/disposable_common.dart, tool/dev.dart...
      error • Missing concrete implementation of getter 'Timer.tick' at lib/src/common/disposable.dart:83:7 • non_abstract_class_inherits_abstract_member_one
    1 error found.

Analysis failed.
```

# Changes
 - Implement tick, but for now just throw unsupported. This lets the library work under Dart 1 & 2.
 - Turn on Travis CI testing for both versions of Dart to make sure it works in both places.
