### PR TITLE
MSODP-263 add applyToItem method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ script:
   - pub run dart_dev gen-test-runner --check
   - pub run dart_dev format --check
   - pub run dart_dev analyze
+  - pub run dart_dev test
   - pub run dart_dev coverage --no-html
-  - pub run dart_dev test # Remove once coverage works with Dart latest
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ script:
   - pub run dart_dev gen-test-runner --check
   - pub run dart_dev format --check
   - pub run dart_dev analyze
-  - pub run dart_dev test
-  - pub run dart_dev coverage --no-html
+  #- pub run dart_dev coverage --no-html
+  - pub run dart_dev test # Remove once coverage works with Dart latest
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ sudo: required
 dart:
   - 1.24.3
   - stable
-  - dev
 addons:
   apt:
     packages:
@@ -41,6 +40,6 @@ script:
   - pub run dart_dev gen-test-runner --check
   - pub run dart_dev format --check
   - pub run dart_dev analyze
-  #- pub run dart_dev coverage --no-html
+  - pub run dart_dev coverage --no-html
   - pub run dart_dev test # Remove once coverage works with Dart latest
   - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+
 import 'package:w_common/func.dart';
 import 'package:w_common/src/common/disposable.dart';
 

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -381,8 +381,9 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   ///
   /// This does not perform a [get] or [getAsync], and as a result, will not
   /// affect retention or removal of a [TIdentifier][TValue] pair from the cache.
-  /// If any callbacks are in fight on removal of [TIdentifier] [TValue] pair
-  /// [didRemove] will not event until callback has completed.
+  ///
+  /// Any [TIdentifier] [TValue] pair removals will wait for the Future returned by
+  /// the call to [callback] before emitting [didRemove] events.
   ///
   /// If the [Cache] [isOrWillBeDisposed] then a [StateError] is thrown.
   Future<bool> applyToItem(

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -172,7 +172,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// If the [Cache] [isOrWillBeDisposed] then a [StateError] is thrown.
   @mustCallSuper
   Future<TValue> get(TIdentifier id, Func<TValue> valueFactory) {
-    _log.finest("get id: $id");
+    _log.finest('get id: $id');
     _throwWhenDisposed('get');
     _cachingStrategy.onWillGet(id);
     // Await any pending cached futures
@@ -230,7 +230,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// If the [Cache] [isOrWillBeDisposed] then a [StateError] is thrown.
   @mustCallSuper
   Future<TValue> getAsync(TIdentifier id, Func<Future<TValue>> valueFactory) {
-    _log.finest("getAsync id: $id");
+    _log.finest('getAsync id: $id');
     _throwWhenDisposed('getAsync');
     _cachingStrategy.onWillGet(id);
     // Await any pending cached futures
@@ -257,7 +257,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// the current [CachingStrategy].
   @mustCallSuper
   Future<Null> release(TIdentifier id) {
-    _log.finest("release id: $id");
+    _log.finest('release id: $id');
     _throwWhenDisposed('release');
     // Await any pending cached futures
     if (_cache.containsKey(id)) {
@@ -284,7 +284,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// If the [Cache] [isOrWillBeDisposed] then a [StateError] is thrown.
   @mustCallSuper
   Future<Null> remove(TIdentifier id) {
-    _log.finest("remove id: $id");
+    _log.finest('remove id: $id');
     _throwWhenDisposed('remove');
     if (_cache.containsKey(id)) {
       _cachingStrategy.onWillRemove(id);
@@ -357,7 +357,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   ///     }
   Future<TValue> weakGet(TIdentifier id) {
     _throwWhenDisposed('weakGet');
-    _log.finest("weakGet id: $id");
+    _log.finest('weakGet id: $id');
     return _cache[id];
   }
 

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -152,19 +152,19 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// To be removed: 2.0.0
   ///
   /// This entry point is deprecated in favor of the more precisely named
-  /// [releasedKeys] and [nonReleasedKeys].
+  /// [releasedKeys] and [liveKeys].
   @deprecated
   Iterable<TIdentifier> get keys => _cache.keys;
 
   /// Keys that have not been released.
-  Iterable<TIdentifier> get nonReleasedKeys =>
+  Iterable<TIdentifier> get liveKeys =>
       _cache.keys.where((TIdentifier key) => !_isReleased[key]);
 
   /// Values that have not been released.
   ///
   /// To access a released value a [get] or [getAsync] should be used.
-  Future<Iterable<TValue>> get nonReleasedValues =>
-      Future.wait(nonReleasedKeys.map((TIdentifier key) => _cache[key]));
+  Future<Iterable<TValue>> get liveValues =>
+      Future.wait(liveKeys.map((TIdentifier key) => _cache[key]));
 
   /// Keys that have been released but are not yet removed.
   Iterable<TIdentifier> get releasedKeys =>
@@ -178,9 +178,9 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// To be removed: 2.0.0
   ///
   /// This entry point is deprecated in favor of the more precisely named
-  /// [nonReleasedValues].
+  /// [liveValues].
   @deprecated
-  Future<Iterable<TValue>> get values => nonReleasedValues;
+  Future<Iterable<TValue>> get values => liveValues;
 
   /// Does the [Cache] contain the given [TIdentifier]?
   ///
@@ -189,7 +189,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// Deprecated: 1.12.0
   /// To be removed: 2.0.0
   ///
-  /// This entry point is deprecated in favor of using [nonReleasedKeys].contains
+  /// This entry point is deprecated in favor of using [liveKeys].contains
   /// or [releasedKeys].contains directly.
   @deprecated
   bool containsKey(TIdentifier id) {
@@ -315,10 +315,10 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// Release indicates that consuming code has finished with the [TIdentifier]
   /// [TValue] pair associated with [id]. This pair may be removed immediately or
   /// in time depending on the [CachingStrategy]. Access to the pair will be
-  /// blocked immediately, i.e. the [nonReleasedValues] getter won't report this
+  /// blocked immediately, i.e. the [liveValues] getter won't report this
   /// item, even if the pair isn't immediately removed from the cache. A [get] or
-  /// [getAsync] must be performed to mark the item as not eligible for removal
-  /// and live in the cache again.
+  /// [getAsync] must be performed to mark the item as ineligible for removal and
+  /// live in the cache again.
   ///
   /// If the [Cache] [isOrWillBeDisposed] then a [StateError] is thrown.
   @mustCallSuper

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -87,7 +87,7 @@ class CachingStrategy<TIdentifier, TValue> {
 /// References are retained for the lifecycle of the instance of the [Cache],
 /// unless explicitly removed.
 class Cache<TIdentifier, TValue> extends Object with Disposable {
-  final Logger _log = new Logger('Cache');
+  final Logger _log = new Logger('w_common.Cache');
 
   /// The backing store for values in the [Cache].
   Map<TIdentifier, Future<TValue>> _cache = <TIdentifier, Future<TValue>>{};
@@ -312,11 +312,11 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   /// object that is known to be in the cache.
   ///
   /// This ideally shouldn't be used to create a reference with a lifetime that
-  /// will exceed the time an item exists in the cache. For example this would be
+  /// will exceed the time the item exists in the cache. For example this would be
   /// a bad consumption pattern:
   ///
-  /// (when a reference created with [weakGet] would be alive and when an item
-  /// will be in the cache highlighted on the right).
+  /// The delineation to the right of the code indicates when an item will be in
+  /// the cache and when a reference created with [weakGet] would be alive.
   ///
   ///     var cache = new Cache<String, Disposable>(new LeastRecentlyUsedStrategy(0));
   ///     cache.didRemove.listen((CacheContext context) => context.value.dispose());
@@ -333,7 +333,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   ///     // removed from the cache and disposed on the didRemove callback.             ┃
   ///     danglingReference.manageDisposable(new Disposable());                         ┋
   ///
-  /// An usual consumption pattern would look something like:
+  /// A usual consumption pattern would look something like:
   ///
   ///     class Things {
   ///       Cache<String, Thing> _cache =
@@ -356,6 +356,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   ///       }
   ///     }
   Future<TValue> weakGet(TIdentifier id) {
+    _throwWhenDisposed('weakGet');
     _log.finest("weakGet id: $id");
     return _cache[id];
   }

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -198,7 +198,7 @@ class Cache<TIdentifier, TValue> extends Object with Disposable {
   @deprecated
   bool containsKey(TIdentifier id) {
     _throwWhenDisposed('containsKey');
-    return keys.contains(id) || releasedKeys.contains(id);
+    return liveKeys.contains(id) || releasedKeys.contains(id);
   }
 
   /// Returns a value from the cache for a given [TIdentifier].

--- a/test/unit/browser/cache/cache_test.dart
+++ b/test/unit/browser/cache/cache_test.dart
@@ -439,6 +439,9 @@ void main() {
 
       test('should not run callback if item is in but released from the cache',
           () {
+        cache.didRemove.listen(expectAsync1((CacheContext context) {},
+            count: 0, reason: 'Ensure that cached item is not removed'));
+
         var callbackRan = false;
         cache
           ..release(cachedId)

--- a/test/unit/browser/cache/cache_test.dart
+++ b/test/unit/browser/cache/cache_test.dart
@@ -365,7 +365,7 @@ void main() {
       });
     });
 
-    group('nonReleasedKeys', () {
+    group('liveKeys', () {
       test('should not provide access to released keys', () {
         cache.didRemove.listen(expectAsync1((CacheContext context) {},
             count: 0, reason: 'Ensure that cached item is not removed'));
@@ -386,7 +386,7 @@ void main() {
       });
     });
 
-    group('nonReleasedValues', () {
+    group('liveValues', () {
       test('should not provide access to released values', () async {
         cache.didRemove.listen(expectAsync1((CacheContext context) {},
             count: 0, reason: 'Ensure that cached item is not removed'));
@@ -463,7 +463,8 @@ void main() {
         });
       });
 
-      group('should not event didRemove stream until callback has completed',
+      group(
+          'should not add event to didRemove stream until callback has completed',
           () {
         setUp(() async {
           cache = new Cache<String, Object>(

--- a/test/unit/browser/cache/cache_test.dart
+++ b/test/unit/browser/cache/cache_test.dart
@@ -351,9 +351,8 @@ void main() {
 
     group('keys', () {
       test('should not provide access to released keys', () {
-        // Ensure that cached item is not removed
-        cache.didRemove
-            .listen(expectAsync1((CacheContext context) {}, count: 0));
+        cache.didRemove.listen(expectAsync1((CacheContext context) {},
+            count: 0, reason: 'Ensure that cached item is not removed'));
 
         expect(cache.keys, contains(cachedId));
         cache.release(cachedId);
@@ -362,9 +361,8 @@ void main() {
 
       test('should not provide access to released keys when release is awaited',
           () async {
-        // Ensure that cached item is not removed
-        cache.didRemove
-            .listen(expectAsync1((CacheContext context) {}, count: 0));
+        cache.didRemove.listen(expectAsync1((CacheContext context) {},
+            count: 0, reason: 'Ensure that cached item is not removed'));
 
         expect(cache.keys, contains(cachedId));
         await cache.release(cachedId);
@@ -374,26 +372,24 @@ void main() {
 
     group('values', () {
       test('should not provide access to released values', () async {
-        // Ensure that cached item is not removed
-        cache.didRemove
-            .listen(expectAsync1((CacheContext context) {}, count: 0));
+        cache.didRemove.listen(expectAsync1((CacheContext context) {},
+            count: 0, reason: 'Ensure that cached item is not removed'));
 
         expect(await cache.values, contains(cachedValue));
         // ignore: unawaited_futures
         cache.release(cachedId);
-        expect((await cache.values).contains(cachedValue), isFalse);
+        expect(await cache.values, isNot(contains(cachedValue)));
       });
 
       test(
           'should not provide access to released values when release is awaited',
           () async {
-        // Ensure that cached item is not removed
-        cache.didRemove
-            .listen(expectAsync1((CacheContext context) {}, count: 0));
+        cache.didRemove.listen(expectAsync1((CacheContext context) {},
+            count: 0, reason: 'Ensure that cached item is not removed'));
 
         expect(await cache.values, contains(cachedValue));
         await cache.release(cachedId);
-        expect((await cache.values).contains(cachedValue), isFalse);
+        expect((await cache.values), isNot(contains(cachedValue)));
       });
     });
 
@@ -407,33 +403,36 @@ void main() {
       });
 
       test('should not run callback if item is not in the cache', () {
-        var calbackRan = false;
+        var callbackRan = false;
         cache.applyToItem(notCachedId, (_) {
-          calbackRan = true;
+          callbackRan = true;
         });
 
-        expect(calbackRan, isFalse);
+        expect(callbackRan, isFalse);
       });
 
-      test('should run callback if item is in the cache', () {
-        var calbackRan = false;
-        cache.applyToItem(cachedId, (_) {
-          calbackRan = true;
+      test('should run callback if item is in the cache', () async {
+        var callbackRan = false;
+        cache.applyToItem(cachedId, (Future<Object> value) {
+          callbackRan = true;
+          value.then(expectAsync1((Object value) {
+            expect(value, cachedValue);
+          }));
         });
 
-        expect(calbackRan, isTrue);
+        expect(callbackRan, isTrue);
       });
 
       test('should not run callback if item is in but released from the cache',
           () {
-        var calbackRan = false;
+        var callbackRan = false;
         cache
           ..release(cachedId)
           ..applyToItem(cachedId, (_) {
-            calbackRan = true;
+            callbackRan = true;
           });
 
-        expect(calbackRan, isFalse);
+        expect(callbackRan, isFalse);
       });
 
       test('should throw when disposed', () async {

--- a/test/unit/browser/cache/cache_test.dart
+++ b/test/unit/browser/cache/cache_test.dart
@@ -130,6 +130,26 @@ void main() {
       });
     });
 
+    group('weakGet', () {
+      test('should return cached value when identifier is cached', () async {
+        final value = await cache.weakGet(cachedId);
+        expect(value, same(cachedValue));
+      });
+
+      test('should not call onDidGet', () async {
+        final mockCachingStrategy = new MockCachingStrategy();
+        final childCache = new Cache<String, Object>(mockCachingStrategy);
+        await childCache.weakGet(cachedId);
+
+        verifyNever(mockCachingStrategy.onDidGet(cachedId, cachedValue));
+      });
+
+      test('should throw when disposed', () async {
+        await cache.dispose();
+        expect(() => cache.get(cachedId, () => cachedValue), throwsStateError);
+      });
+    });
+
     group('containsKey', () {
       test('should return false when identifier has not been cached', () {
         expect(cache.containsKey(notCachedId), isFalse);

--- a/test/unit/browser/cache/cache_test.dart
+++ b/test/unit/browser/cache/cache_test.dart
@@ -370,9 +370,9 @@ void main() {
         cache.didRemove.listen(expectAsync1((CacheContext context) {},
             count: 0, reason: 'Ensure that cached item is not removed'));
 
-        expect(cache.nonReleasedKeys, contains(cachedId));
+        expect(cache.liveKeys, contains(cachedId));
         cache.release(cachedId);
-        expect(cache.nonReleasedKeys.contains(cachedId), isFalse);
+        expect(cache.liveKeys.contains(cachedId), isFalse);
       });
 
       test('should not provide access to released keys when release is awaited',
@@ -380,9 +380,9 @@ void main() {
         cache.didRemove.listen(expectAsync1((CacheContext context) {},
             count: 0, reason: 'Ensure that cached item is not removed'));
 
-        expect(cache.nonReleasedKeys, contains(cachedId));
+        expect(cache.liveKeys, contains(cachedId));
         await cache.release(cachedId);
-        expect(cache.nonReleasedKeys.contains(cachedId), isFalse);
+        expect(cache.liveKeys.contains(cachedId), isFalse);
       });
     });
 
@@ -391,10 +391,10 @@ void main() {
         cache.didRemove.listen(expectAsync1((CacheContext context) {},
             count: 0, reason: 'Ensure that cached item is not removed'));
 
-        expect(await cache.nonReleasedValues, contains(cachedValue));
+        expect(await cache.liveValues, contains(cachedValue));
         // ignore: unawaited_futures
         cache.release(cachedId);
-        expect(await cache.nonReleasedValues, isNot(contains(cachedValue)));
+        expect(await cache.liveValues, isNot(contains(cachedValue)));
       });
 
       test(
@@ -403,9 +403,9 @@ void main() {
         cache.didRemove.listen(expectAsync1((CacheContext context) {},
             count: 0, reason: 'Ensure that cached item is not removed'));
 
-        expect(await cache.nonReleasedValues, contains(cachedValue));
+        expect(await cache.liveValues, contains(cachedValue));
         await cache.release(cachedId);
-        expect((await cache.nonReleasedValues), isNot(contains(cachedValue)));
+        expect((await cache.liveValues), isNot(contains(cachedValue)));
       });
     });
 


### PR DESCRIPTION
### Description

Working with consumption in `internal application X` recently has shown that it would be a helpful for the cache to have a get that works like a map get rather than a cache get. In other words the caching strategy would not be informed of the get and it would not count towards against the removal of the item being referenced from the cache. This can be very useful when one wants to mutate an item that is known to be in the cache.

### Changes

Added a method to the cache that will run a callback on an item in the cache without doing a get. As a bonus it will ensure that the events will not be put on the `didRemove` stream until the callback has finished running. To guard against the situation where a consumer chooses to dispose on removal of an object from the cache and applies a long running callback with quite a few awaits. In this circumstance it's possible that the object will be disposed before there callback finishes; which could lead to (in all likelihood benign) exceptions thrown.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

