### PR TITLE
Add formatTimeDifference as it seems generally usable

### DIFF
--- a/lib/time.dart
+++ b/lib/time.dart
@@ -1,0 +1,52 @@
+library w_common.timestamp;
+
+import 'package:intl/intl.dart';
+
+/// The format of a timestamp with no date.
+DateFormat timeFormat = new DateFormat('h:mma');
+
+/// The format of a weekday with no time of day.
+DateFormat weekdayFormat = new DateFormat.EEEE();
+
+/// The format of a month and day with no time of day.
+DateFormat monthDayFormat = new DateFormat.MMMMd();
+
+/// The format of the full date with no time of day.
+DateFormat yearMonthDayFormat = new DateFormat.yMMMd();
+
+/// formating of string in our db
+DateFormat dbFormat = new DateFormat("y-M-dd HH:mm:ss");
+
+/// Formats a DateTime into the 'X ago' string format.
+String formatTimeDifference(DateTime time, {DateTime now}) {
+  now ??= new DateTime.now();
+  final timeOfDay = timeFormat.format(time).toLowerCase();
+  final deltaDays = now.difference(time).inDays.abs();
+
+  if (deltaDays < 1 && now.day == time.day) {
+    // "Today, XX:XXam"
+    return 'Today, $timeOfDay';
+  }
+
+  if (deltaDays < 2 && now.weekday == (time.weekday + 1) % 7) {
+    // "Yesterday, XX:XXam"
+    return 'Yesterday, $timeOfDay';
+  }
+
+  // Weekday check prevents abiguity between comments
+  // made almost a week apart in the same week day.
+  if (deltaDays < 7 && now.weekday != time.weekday) {
+    // "Tuesday, XX:XXam"
+    return '${weekdayFormat.format(time)}, $timeOfDay';
+  }
+
+  // Month check prevents abiguity between comments
+  // made almost a year apart in the same month.
+  if (deltaDays < 365 && (now.year == time.year || now.month != time.month)) {
+    // "January 25, XX:XXam"
+    return '${monthDayFormat.format(time)}, $timeOfDay';
+  }
+
+  // "Jan 5, 2016"
+  return '${yearMonthDayFormat.format(time)}';
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   sdk: '>=1.12.0 <2.0.0'
 
 dependencies:
+  intl: ^0.15.0
   logging: ^0.11.0
   meta: ^1.0.4
 

--- a/test/unit/browser/generated_browser_tests.dart
+++ b/test/unit/browser/generated_browser_tests.dart
@@ -10,6 +10,7 @@ import './cache/reference_counting_strategy_test.dart' as cache_reference_counti
 import './disposable_browser_test.dart' as disposable_browser_test;
 import './invalidation_mixin_test.dart' as invalidation_mixin_test;
 import './json_serializable_test.dart' as json_serializable_test;
+import './time_test.dart' as timestamp_test;
 import 'package:test/test.dart';
 
 void main() {
@@ -20,4 +21,5 @@ void main() {
   disposable_browser_test.main();
   invalidation_mixin_test.main();
   json_serializable_test.main();
+  timestamp_test.main();
 }

--- a/test/unit/browser/time_test.dart
+++ b/test/unit/browser/time_test.dart
@@ -1,0 +1,72 @@
+import 'package:test/test.dart';
+
+import 'package:w_common/time.dart';
+
+void main() {
+  group('Utilities', () {
+    test('formatting timeAgo', () {
+      DateTime past;
+      DateTime newDay;
+      DateTime oldDay;
+
+      // today
+
+      // less than 24 hours ago && same day
+      newDay = new DateTime.utc(2018, 1, 1, 23, 59, 59);
+      oldDay = new DateTime.utc(2018, 1, 1);
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("Today, "));
+
+      // yesterday
+
+      // different day
+      newDay = new DateTime.utc(2018, 1, 1);
+      oldDay = newDay.subtract(const Duration(seconds: 1));
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("Yesterday, "));
+
+      // very nearly 48 hours
+      newDay = new DateTime.utc(2018, 1, 2, 23, 59, 59);
+      oldDay = new DateTime.utc(2018, 1, 1);
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("Yesterday, "));
+
+      // week
+
+      // at midnight, the day before yesterday was one day and 1 second ago
+      newDay = new DateTime.utc(2018, 1, 1);
+      oldDay = newDay.subtract(const Duration(days: 1, seconds: 1));
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("${weekdayFormat.format(oldDay)}, "));
+
+      // less than 7 days diff, and not on the same week day
+      newDay = new DateTime.utc(2018, 1, 1, 1);
+      oldDay = newDay.subtract(const Duration(days: 6, seconds: 1));
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("${weekdayFormat.format(oldDay)}, "));
+
+      // month
+
+      // less than 7 days diff, same week day
+      newDay = new DateTime.utc(2018, 1, 1, 1);
+      oldDay = newDay.subtract(const Duration(days: 6, hours: 23));
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("${monthDayFormat.format(oldDay)}, "));
+
+      // 7 day diff
+      newDay = new DateTime.utc(2018, 1, 1, 23, 59, 59);
+      oldDay = newDay.subtract(const Duration(days: 7));
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("${monthDayFormat.format(oldDay)}, "));
+
+      // 9 day diff
+      newDay = new DateTime.utc(2018, 1, 1, 23, 59, 59);
+      oldDay = newDay.subtract(const Duration(days: 9));
+      expect(formatTimeDifference(oldDay, now: newDay), startsWith("${monthDayFormat.format(oldDay)}, "));
+
+      // year
+
+      // 365 day diff
+      newDay = new DateTime.utc(2018, 1, 1);
+      oldDay = newDay.subtract(const Duration(days: 365));
+      expect(formatTimeDifference(oldDay, now: newDay), "${yearMonthDayFormat.format(oldDay)}");
+
+      // look out a ways
+      past = new DateTime.now().subtract(const Duration(days: 9999));
+      expect(formatTimeDifference(past), "${yearMonthDayFormat.format(past)}");
+    });
+  });
+}


### PR DESCRIPTION
https://jira.atl.workiva.net/browse/DOCPLAT-3320

### Description
I needed a method to translate a time difference into a human readable string.  Found this algorithm in w_comments that fits the bill.  Figured this would be a good home for it.

### Changes
Move w_comments code over to this library for general use.

### Semantic Versioning
- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA
- [ ] CI passes

### Code Review
@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

