### PR TITLE
MSODP-839 Attach a leak flag factory to window when in debug mode

### DIFF
--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -14,6 +14,7 @@
 
 import 'dart:async';
 import 'dart:html';
+import 'dart:js' as js;
 
 import 'package:meta/meta.dart';
 import 'package:w_common/func.dart';
@@ -133,16 +134,33 @@ class _InnerDisposable extends disposable_common.Disposable {
 /// composition to include the [Disposable] machinery without changing
 /// the public interface of our class or polluting its lifecycle.
 class Disposable implements disposable_common.Disposable {
+  /// The name of the factory function added to the window that produces
+  /// [LeakFlag] objects when called.
+  static const String leakFlagFactoryName = 'leakFlagFactory';
+
   /// Disables logging enabled by [enableDebugMode].
-  static void disableDebugMode() =>
-      disposable_common.Disposable.disableDebugMode();
+  static void disableDebugMode() {
+    disposable_common.Disposable.disableDebugMode();
+
+    // If there is a leak flag factory function on the window, remove it.
+    if (js.context.hasProperty(leakFlagFactoryName)) {
+      js.context.deleteProperty(leakFlagFactoryName);
+    }
+  }
 
   /// Causes messages to be logged for various lifecycle and management events.
   ///
   /// This should only be used for debugging and profiling as it can result
   /// in a huge number of messages being generated.
-  static void enableDebugMode() =>
-      disposable_common.Disposable.enableDebugMode();
+  static void enableDebugMode() {
+    disposable_common.Disposable.enableDebugMode();
+
+    // Attach a leak flag factory function to the window to allow consumers to
+    // attach leak flags to arbitrary objects.
+    if (!js.context.hasProperty(leakFlagFactoryName)) {
+      js.context[leakFlagFactoryName] = _leakFlagFactory;
+    }
+  }
 
   final _InnerDisposable _disposable = new _InnerDisposable();
 
@@ -313,4 +331,8 @@ class Disposable implements disposable_common.Disposable {
       eventTarget.removeEventListener(event, callback, useCapture);
     });
   }
+}
+
+disposable_common.LeakFlag _leakFlagFactory(String description) {
+  return new disposable_common.LeakFlag(description);
 }

--- a/test/unit/browser/disposable_browser_test.dart
+++ b/test/unit/browser/disposable_browser_test.dart
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 import 'dart:html';
+import 'dart:js' as js;
 
-import 'package:test/test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:w_common/src/browser/disposable_browser.dart';
+import 'package:w_common/src/common/disposable.dart' show LeakFlag;
 
 import '../disposable_common.dart';
 import './browser_stubs.dart';
@@ -96,6 +99,28 @@ void main() {
 
         element.dispatchEvent(event);
         expect(numberOfEventCallbacks, equals(0));
+      });
+    });
+
+    group('debug mode', () {
+      test('should not add leak flag factory to window by default', () {
+        expect(js.context.hasProperty(Disposable.leakFlagFactoryName), isFalse);
+      });
+
+      test('should add leak flag factory to window when enabled', () {
+        Disposable.enableDebugMode();
+        final LeakFlag leakFlag =
+            js.context.callMethod(Disposable.leakFlagFactoryName, ['foo']);
+        expect(leakFlag, isNotNull);
+        expect(leakFlag.description, equals('foo'));
+      });
+
+      test('should remove leak flag factory from window when disabled', () {
+        Disposable.enableDebugMode();
+        expect(js.context.hasProperty(Disposable.leakFlagFactoryName), isTrue);
+
+        Disposable.disableDebugMode();
+        expect(js.context.hasProperty(Disposable.leakFlagFactoryName), isFalse);
       });
     });
   });


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description
In certain situations it might be helpful to provide a factory function on the window that produces a LeakFlag object. For example, when code is written in another language, such as Go, and transpiled to JS it would be nice to be able to use `LeakFlag`s to search for memory leaks in the transpiled code too.

### Changes
When the disposable debug mode is enabled we will now attach a factory function to the window that will produce a `LeakFlag` object.

### Semantic Versioning

- [x] **Patch**
  - [x] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [ ] **Minor**
  - [ ] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA
- [ ] CI passes

### Code Review
@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf
@Workiva/missoula-docplat 

### FYI
@regenvanwalbeek-wf 