### PR TITLE
implement idle task queue using requestIdleCallback

### DIFF
--- a/lib/idle_task_queue.dart
+++ b/lib/idle_task_queue.dart
@@ -1,0 +1,78 @@
+@JS()
+library idle_task_queue;
+
+import 'dart:async';
+import 'dart:html';
+import 'dart:js';
+
+import 'package:js/js.dart';
+import 'package:meta/meta.dart';
+
+/// This calls the [requestIdleCallback] API directly.
+///
+/// Note that `requestIdleCallbackPolyfill.js` or another polyfill like it must
+/// be included in order to use this API in browsers such as IE 11 or Edge which
+/// do not support it.
+///
+/// Most tasks could be added using [enqueueIdleTask] instead.
+@JS()
+external num requestIdleCallback(Function callback, [Map options]);
+
+/// A handler which will be called during idle time.
+typedef void IdleTaskHandler<T>(T input);
+
+@immutable
+class _IdleTask<T> {
+  final IdleTaskHandler<T> handler;
+  final T input;
+
+  _IdleTask(this.handler, this.input);
+}
+
+/// Adds the task to a queue which will be called during idle time.
+void enqueueIdleTask<T>(IdleTaskHandler<T> handler, T input) {
+  // For unsupported browsers when the polyfill is not available,
+  // we still want the task to be called eventually.
+  if (!_doesBrowserSupportIdleCallback) {
+    new Future.delayed(const Duration()).then((_) => handler(input));
+    return;
+  }
+
+  _taskQueue.add(new _IdleTask<T>(handler, input));
+
+  // Start running the queue if it has not been started.
+  // If there is a task, the queue is already running and doesn't
+  // need to be started again.
+  if (_currentTask == null) {
+    _currentTask = requestIdleCallback(
+      allowInterop(_runQueue),
+      <String, dynamic>{'timeout': 1000},
+    );
+  }
+}
+
+void _runQueue(IdleDeadline deadline) {
+  while (!deadline.didTimeout &&
+      deadline.timeRemaining() > 0 &&
+      _taskQueue.isNotEmpty) {
+    final task = _taskQueue.removeAt(0);
+    task.handler(task.input);
+  }
+
+  if (_taskQueue.isNotEmpty) {
+    _currentTask = requestIdleCallback(
+      allowInterop(_runQueue),
+      <String, dynamic>{
+        'timeout': 1000,
+      },
+    );
+  } else {
+    _currentTask = null;
+  }
+}
+
+bool get _doesBrowserSupportIdleCallback =>
+    context['requestIdleCallback'] != null;
+
+final List<_IdleTask> _taskQueue = [];
+num _currentTask;

--- a/lib/idle_task_queue.dart
+++ b/lib/idle_task_queue.dart
@@ -1,22 +1,22 @@
-@JS()
+// @JS()
 library idle_task_queue;
 
 import 'dart:async';
 import 'dart:html';
 import 'dart:js';
 
-import 'package:js/js.dart';
+// import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 
-/// This calls the [requestIdleCallback] API directly.
+// / This calls the [requestIdleCallback] API directly.
 ///
 /// Note that `requestIdleCallbackPolyfill.js` or another polyfill like it must
 /// be included in order to use this API in browsers such as IE 11 or Edge which
 /// do not support it.
 ///
 /// Most tasks could be added using [enqueueIdleTask] instead.
-@JS()
-external num requestIdleCallback(Function callback, [Map options]);
+// @JS()
+// external int requestIdleCallback(IdleRequestCallback callback, [Map options]);
 
 /// A handler which will be called during idle time.
 typedef void IdleTaskHandler<T>(T input);
@@ -44,7 +44,7 @@ void enqueueIdleTask<T>(IdleTaskHandler<T> handler, T input) {
   // If there is a task, the queue is already running and doesn't
   // need to be started again.
   if (_currentTask == null) {
-    _currentTask = requestIdleCallback(
+    _currentTask = window.requestIdleCallback(
       allowInterop(_runQueue),
       <String, dynamic>{'timeout': 1000},
     );
@@ -60,7 +60,7 @@ void _runQueue(IdleDeadline deadline) {
   }
 
   if (_taskQueue.isNotEmpty) {
-    _currentTask = requestIdleCallback(
+    _currentTask = window.requestIdleCallback(
       allowInterop(_runQueue),
       <String, dynamic>{
         'timeout': 1000,
@@ -75,4 +75,4 @@ bool get _doesBrowserSupportIdleCallback =>
     context['requestIdleCallback'] != null;
 
 final List<_IdleTask> _taskQueue = [];
-num _currentTask;
+int _currentTask;

--- a/lib/idle_task_queue.dart
+++ b/lib/idle_task_queue.dart
@@ -7,6 +7,8 @@ import 'dart:js';
 
 import 'package:meta/meta.dart';
 
+const Duration _immediately = const Duration();
+
 /// A handler which will be called during idle time.
 typedef void IdleTaskHandler<T>(T input);
 
@@ -14,20 +16,27 @@ typedef void IdleTaskHandler<T>(T input);
 class _IdleTask<T> {
   final IdleTaskHandler<T> handler;
   final T input;
+  final Completer<Null> completer = new Completer<Null>();
 
   _IdleTask(this.handler, this.input);
 }
 
 /// Adds the task to a queue which will be called during idle time.
-void enqueueIdleTask<T>(IdleTaskHandler<T> handler, T input) {
+///
+/// Returns the `Future` which will complete when the task has run.
+///
+/// May complete with an error if the task throws when called.
+Future<Null> enqueueIdleTask<T>(IdleTaskHandler<T> handler, T input) {
   // For unsupported browsers when the polyfill is not available,
   // we still want the task to be called eventually.
   if (!_doesBrowserSupportIdleCallback) {
-    new Future.delayed(const Duration()).then((_) => handler(input));
-    return;
+    return new Future.delayed(_immediately).then((_) async {
+      handler(input);
+    });
   }
 
-  _taskQueue.add(new _IdleTask<T>(handler, input));
+  final task = new _IdleTask<T>(handler, input);
+  _taskQueue.add(task);
 
   // Start running the queue if it has not been started.
   // If there is a task, the queue is already running and doesn't
@@ -38,6 +47,8 @@ void enqueueIdleTask<T>(IdleTaskHandler<T> handler, T input) {
       <String, dynamic>{'timeout': 1000},
     );
   }
+
+  return task.completer.future;
 }
 
 void _runQueue(IdleDeadline deadline) {
@@ -45,7 +56,17 @@ void _runQueue(IdleDeadline deadline) {
       deadline.timeRemaining() > 0 &&
       _taskQueue.isNotEmpty) {
     final task = _taskQueue.removeAt(0);
-    task.handler(task.input);
+    try {
+      task.handler(task.input);
+      task.completer.complete();
+    } catch (e, t) {
+      // Listeners to the completer future might throw.
+      if (!task.completer.isCompleted) {
+        try {
+          task.completer.completeError(e, t);
+        } catch (_) {}
+      }
+    }
   }
 
   if (_taskQueue.isNotEmpty) {

--- a/lib/idle_task_queue.dart
+++ b/lib/idle_task_queue.dart
@@ -5,18 +5,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:js';
 
-// import 'package:js/js.dart';
 import 'package:meta/meta.dart';
-
-// / This calls the [requestIdleCallback] API directly.
-///
-/// Note that `requestIdleCallbackPolyfill.js` or another polyfill like it must
-/// be included in order to use this API in browsers such as IE 11 or Edge which
-/// do not support it.
-///
-/// Most tasks could be added using [enqueueIdleTask] instead.
-// @JS()
-// external int requestIdleCallback(IdleRequestCallback callback, [Map options]);
 
 /// A handler which will be called during idle time.
 typedef void IdleTaskHandler<T>(T input);

--- a/lib/requestIdleCallbackPolyfill.js
+++ b/lib/requestIdleCallbackPolyfill.js
@@ -1,0 +1,24 @@
+// A poyfill for requestIdleCallback.
+//
+// For: IE 11, Edge, and Firefox
+// Source: https://www.npmjs.com/package/requestidlecallback-polyfill
+// https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback
+window.requestIdleCallback =
+    window.requestIdleCallback ||
+    function(cb) {
+        var start = Date.now();
+        return setTimeout(function() {
+            cb({
+                didTimeout: false,
+                timeRemaining: function() {
+                    return Math.max(0, 50 - (Date.now() - start));
+                },
+            });
+        }, 1);
+    };
+
+window.cancelIdleCallback =
+    window.cancelIdleCallback ||
+    function(id) {
+        clearTimeout(id);
+    };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   intl: ">=0.14.0 <0.16.0"
-  js: any # TODO figure out this range
+  js: ^0.6.1+1 # TODO figure out this range
   logging: ^0.11.0
   meta: ^1.0.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   intl: ">=0.14.0 <0.16.0"
+  js: any # TODO figure out this range
   logging: ^0.11.0
   meta: ^1.0.4
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 
 dependencies:
   intl: ">=0.14.0 <0.16.0"
-  js: ^0.6.1+1 # TODO figure out this range
   logging: ^0.11.0
   meta: ^1.0.4
 


### PR DESCRIPTION
### Description

Adds library-level [requestIdleCallback](https://developer.mozilla.org/en-US/docs/Web/API/Window/requestIdleCallback) support in Dart.

Also adds an `IdleTaskQueue`, which can be used to queue general tasks that should only be run during idle time so that consumers don't need to write their own redundant yielding logic.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

TODO: Standard testing might not work here because in CI `requestIdleCallback` never fires because there is no idle frame. We need another test strategy for this one.

#### Testing Suggestion

My apologies to OSSers who can't see these things:

- PR to put AI reporting in idle task queue: https://github.com/Workiva/app_intelligence_dart/pull/763
- PR to put polyfill in Wdesk: https://github.com/Workiva/wdesk_sdk/pull/3124
- Test branch https://github.com/Workiva/text_doc_client/pull/7145

Use the test branch to verify that reporting (using networking) is not done during idle frames. Caveat: in debug mode, the console reporter is utilized, and that does *not* utilize idle tasks for obvious reasons.

### Code Review

@Workiva/app-frameworks 
