### PR TITLE
Add disposable name and tidy up tooling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dart:
   - stable
 
 script:
-  - dartfmt -n --set-exit-if-changed example lib test tool
+  - tool/format.sh
   - dartanalyzer lib test/unit
   - pub publish --dry-run
   - xvfb-run --server-args="-screen 0 1024x768x24" tool/test.sh

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -160,8 +160,8 @@ class Disposable implements disposable_common.Disposable {
   /// and manually attach it to an object. For example, this may be useful in
   /// code transpiled to JavaScript from another language.
   static void enableDebugMode({bool disableLogging, bool disableTelemetry}) {
-    disposable_common.Disposable
-        .enableDebugMode(disableLogging: disableLogging, disableTelemetry: disableTelemetry);
+    disposable_common.Disposable.enableDebugMode(
+        disableLogging: disableLogging, disableTelemetry: disableTelemetry);
 
     // Attach a leak flag factory function to the window to allow consumers to
     // attach leak flags to arbitrary objects.
@@ -174,6 +174,9 @@ class Disposable implements disposable_common.Disposable {
 
   @override
   Future<Null> get didDispose => _disposable.didDispose;
+
+  @override
+  String get disposableTypeName => disposable_common.defaultDisposableTypeName;
 
   @override
   int get disposalTreeSize => _disposable.disposalTreeSize;

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -22,6 +22,9 @@ import 'package:w_common/src/common/disposable_manager.dart';
 import 'package:w_common/src/common/disposable_state.dart';
 import 'package:w_common/src/common/managed_stream_subscription.dart';
 
+/// The default value of the `disposableTypeName` field.
+const String defaultDisposableTypeName = 'Disposable';
+
 // ignore: one_member_abstracts
 abstract class _Disposable {
   Future<Null> dispose();
@@ -280,6 +283,14 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
 
   /// A [Future] that will complete when this object has been disposed.
   Future<Null> get didDispose => _didDispose.future;
+
+  /// A type name, similar to [runtimeType] but intended to work
+  /// with minified code.
+  ///
+  /// Consumers should override if they would like to provide a type
+  /// name for use in debugging. This name is included in exceptions
+  /// thrown by this class.
+  String get disposableTypeName => defaultDisposableTypeName;
 
   /// The total size of the disposal tree rooted at the current Disposable
   /// instance.
@@ -710,11 +721,12 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     }
     // ignore: deprecated_member_use
     if (isDisposing) {
-      throw new StateError('$methodName not allowed, object is disposing');
+      throw new StateError(
+          '$disposableTypeName.$methodName not allowed, object is disposing');
     }
     if (isDisposed) {
       throw new StateError(
-          '$methodName not allowed, object is already disposed');
+          '$disposableTypeName.$methodName not allowed, object is already disposed');
     }
   }
 

--- a/tool/format.sh
+++ b/tool/format.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+dartfmt -w --set-exit-if-changed example lib test tool

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -1,14 +1,5 @@
-#!/bin/bash
-# Fast fail the script on failures.
+#!/bin/sh
 set -e
 
-DART_VERSION=$(dart --version 2>&1)
-DART_2_PREFIX="Dart VM version: 2"
-
-if [[ $DART_VERSION = $DART_2_PREFIX* ]]; then
-    echo -e 'pub run build_runner test -- -p chrome -p vm --reporter=expanded'
-    pub run build_runner test -- -p chrome -p vm --reporter=expanded
-else
-    pub run test -p chrome -p vm --reporter=expanded
-fi
+pub run test -p chrome -p vm --reporter=expanded
 


### PR DESCRIPTION
> Please apply the appropriate label to your PR:
> - bug / critical
> - improvement / optimization / tech-debt / UX
> - feature

### Description

It might be useful for consumers to be able to see which class has thrown a given exception while debugging.

### Changes

Add an optional "name" field to `Disposable` to help with debugging.

### Semantic Versioning

- [ ] **Patch**
  - [ ] This change does not affect the public API
  - [ ] This change fixes existing incorrect behavior without any additions
- [x] **Minor**
  - [x] This change adds something to the public API
  - [ ] This change deprecates a part of the public API
* [ ] Major
  - [ ] This change modifies part of the public API in a backwards-incompatible manner
  - [ ] This change removes part of the public API

### Testing/QA

- [ ] CI passes

### Code Review

@dustinlessard-wf
@evanweible-wf
@jayudey-wf
@maxwellpeterson-wf
@sebastianmalysa-wf
@trentgrover-wf

