### PR TITLE
CPLAT-5075: Add name test util

### DIFF
--- a/example/errors/example.dart
+++ b/example/errors/example.dart
@@ -82,9 +82,12 @@ void main() {
 
   MyManager myManager;
 
-  ButtonElement createMyManagerButton = querySelector('#create-MyManager-button');
-  ButtonElement disposeMyManagerButton = querySelector('#dispose-MyManager-button');
-  ButtonElement posthumousMyManagerButton = querySelector('#posthumous-MyManager-button');
+  ButtonElement createMyManagerButton =
+      querySelector('#create-MyManager-button');
+  ButtonElement disposeMyManagerButton =
+      querySelector('#dispose-MyManager-button');
+  ButtonElement posthumousMyManagerButton =
+      querySelector('#posthumous-MyManager-button');
 
   createMyManagerButton.onClick.listen((_) {
     myManager = new MyManager();
@@ -107,8 +110,10 @@ void main() {
   });
 
   ErrorCreator errorCreator;
-  ButtonElement createErrorCreatorButton = querySelector('#create-ErrorCreator-button');
-  ButtonElement disposeErrorCreatorButton = querySelector('#dispose-ErrorCreator-button');
+  ButtonElement createErrorCreatorButton =
+      querySelector('#create-ErrorCreator-button');
+  ButtonElement disposeErrorCreatorButton =
+      querySelector('#dispose-ErrorCreator-button');
 
   createErrorCreatorButton.onClick.listen((_) {
     errorCreator = new ErrorCreator();

--- a/lib/test_utils.dart
+++ b/lib/test_utils.dart
@@ -1,0 +1,26 @@
+import 'dart:mirrors';
+
+import 'package:w_common/disposable.dart';
+
+/// A helper to assert that the `disposableTypeName` getter has been,
+/// and remains, correctly overridden for a given [Disposable] subclass.
+///
+/// Example usage might be to call this from a test:
+///
+/// ```
+/// expect(
+///   verifyDisposableTypeName(myObject, makeAssertion: false),
+///   new Symbol('MyObject'),
+/// );
+/// ```
+///
+/// By default, it will assert that the `disposableTypeName` matches the
+/// simple class name. It will also return the [Symbol] that represents
+/// the class name.
+Symbol verifyDisposableTypeName(Disposable object, {bool makeAssertion: true}) {
+  final type = reflect(object).type.simpleName;
+  if (makeAssertion == true) {
+    assert(type == new Symbol(object.disposableTypeName));
+  }
+  return type;
+}

--- a/test/unit/vm/test_utils_test.dart
+++ b/test/unit/vm/test_utils_test.dart
@@ -1,0 +1,45 @@
+@TestOn('vm')
+import 'package:test/test.dart';
+import 'package:w_common/disposable.dart';
+import 'package:w_common/test_utils.dart';
+
+void main() {
+  group('test_utils', () {
+    group('verifyDisposableTypeName', () {
+      test(
+          'should throw AssertionError on name mismatch when makeAssertion == true',
+          () {
+        final c = new MismatchClass();
+        expect(() => verifyDisposableTypeName(c, makeAssertion: true),
+            throwsA(isInstanceOf<AssertionError>()));
+      });
+
+      test(
+          'should not throw AssertionError on name mismatch when makeAssertion != true',
+          () {
+        final c = new MismatchClass();
+        expect(() => verifyDisposableTypeName(c, makeAssertion: false),
+            returnsNormally);
+      });
+
+      test('should always return name when names match', () {
+        final c = new MatchClass();
+        final name = verifyDisposableTypeName(c);
+        expect(name, new Symbol('MatchClass'));
+      });
+
+      test('should always return name when makeAssertion = false', () {
+        final c = new MismatchClass();
+        final name = verifyDisposableTypeName(c, makeAssertion: false);
+        expect(name, new Symbol('MismatchClass'));
+      });
+    });
+  });
+}
+
+class MatchClass<T> extends Disposable {
+  @override
+  String get disposableTypeName => 'MatchClass';
+}
+
+class MismatchClass<T> extends Disposable {}


### PR DESCRIPTION
# [CPLAT-5075](https://jira.atl.workiva.net/browse/CPLAT-5075)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-5075)

## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
@joshprzybyszewski-wf implemented `disposableTypeName` for several of our projects and it was suggested that it might be nice to unit test that the names match the class names. This seemed like something that could be provided as a test utility here.

## Changes
  <!-- What this PR changes to fix the problem. -->
Add `verifyDisposableTypeName` as a test utility (using a new entry point).

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->
Add a test utility to assist in asserting that implementations of `disposableTypeName` are, and remain, correct.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

As long as CI passes we should be fine here.

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: @joshprzybyszewski-wf <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: CI passes
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
