### PR TITLE
Loosen typing of `getManagedDelayedFuture` parameter

### DIFF
--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -221,7 +221,7 @@ class Disposable implements disposable_common.Disposable {
   }
 
   @override
-  Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) =>
+  Future<T> getManagedDelayedFuture<T>(Duration duration, FutureOr<T> callback()) =>
       _disposable.getManagedDelayedFuture(duration, callback);
 
   @override

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -453,7 +453,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
 
   @mustCallSuper
   @override
-  Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) {
+  Future<T> getManagedDelayedFuture<T>(Duration duration, FutureOr<T> callback()) {
     _throwOnInvalidCall2(
         'getManagedDelayedFuture', 'duration', 'callback', duration, callback);
     var completer = new Completer<T>();

--- a/lib/src/common/disposable_manager.dart
+++ b/lib/src/common/disposable_manager.dart
@@ -138,7 +138,7 @@ abstract class DisposableManagerV3 implements DisposableManagerV2 {
   ///
   /// If the object is disposed before the time has elapsed the future
   /// will complete with an [ObjectDisposedException] error.
-  Future<T> getManagedDelayedFuture<T>(Duration duration, T callback());
+  Future<T> getManagedDelayedFuture<T>(Duration duration, FutureOr<T> callback());
 
   /// Ensure that a completer is completed when the object is disposed.
   ///


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

I'm updating a private consumer of this repo to Dart 2:

```
  Future<Thing> waitForThingToFinish(Thing thing) async {
    Completer<Thing> c = new Completer();

    thing = await getThingStatus(thing.url);
    if (thing.status == Done) {
      c.complete(thing);
    } else {
      return getManagedDelayedFuture<Future<Thing>>(pollingInterval, () => waitForThingToFinish(thing));
    }

    return c.future;
  }
```

## Changes
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
