### PR TITLE
CPLAT-5536: Add --watch option to compile_sass script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ includes the following:
     pub run w_common:compile_sass
     ```
     from the root of your package that depends on w_common.
+    * It can also be used as a watcher - great for when you're 
+      doing a lot of work on `.scss` files and don't want to have to
+      remember to keep re-running the script after each change.
+      ```
+      pub run w_common:compile_sass --watch
+      ```
     * Run 
       ```
       pub run w_common:compile_sass -h

--- a/bin/compile_sass.dart
+++ b/bin/compile_sass.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:w_common/src/bin/compile_sass.dart' as compiler;
 
-void main(List<String> args) => compiler.main(args);
+Future<Null> main(List<String> args) async => await compiler.main(args);

--- a/lib/src/bin/compile_sass.dart
+++ b/lib/src/bin/compile_sass.dart
@@ -38,23 +38,24 @@ const Map<String, sass.OutputStyle> outputStyleArgToOutputStyleValue = const {
 Future<Null> main(List<String> args) async {
   final parser = new ArgParser()
     ..addMultiOption(outputStyleArg,
+        abbr: 's',
         help: 'The output style used to format the compiled CSS.',
         defaultsTo: outputStyleDefaultValue,
         splitCommas: true)
     ..addOption(expandedOutputStyleFileExtensionArg,
         help:
-            'The file extension that will be used for the CSS compiled using `expanded` outputStyle.',
+            'The file extension that will be used for the CSS compiled using \n`expanded` outputStyle.',
         defaultsTo: expandedOutputStyleFileExtensionDefaultValue)
     ..addOption(compressedOutputStyleFileExtensionArg,
         help:
-            'The file extension that will be used for the CSS compiled using `compressed` outputStyle unless more than one `--$outputStyleArg` is defined. When more than one outputStyle is used, the extension for compressed CSS will be `.min.css` no matter what.',
+            'The file extension that will be used for the CSS compiled using \n`compressed` outputStyle unless more than one `--$outputStyleArg` \nis defined. \nWhen more than one outputStyle is used, the extension for \ncompressed CSS will be `.min.css` no matter what.',
         defaultsTo: compressedOutputStyleFileExtensionDefaultValue)
     ..addOption(sourceDirArg,
         help:
-            'The directory where the `.scss` files that you want to compile live. Defaults to $sourceDirDefaultValue, or the value of `--$outputDirArg`, if specified.')
+            'The directory where the `.scss` files that you want to compile live. \n(defaults to $sourceDirDefaultValue, or the value of `--$outputDirArg`, if specified.)')
     ..addOption(outputDirArg,
         help:
-            'The directory where the compiled CSS should go. Defaults to $outputDirDefaultValue, or the value of `--$sourceDirArg`, if specified.')
+            'The directory where the compiled CSS should go. \n(defaults to $outputDirDefaultValue, or the value of `--$sourceDirArg`, if specified.)')
     ..addMultiOption(watchDirsArg,
         splitCommas: true,
         defaultsTo: const <String>[],
@@ -65,13 +66,11 @@ Future<Null> main(List<String> args) async {
         help: 'Watch stylesheets and recompile when they change.')
     ..addFlag(checkFlag,
         abbr: 'c',
-        defaultsTo: false,
         negatable: false,
         help:
-            'When set to true, no `.css` outputs will be written to disk, and a non-zero exit code will be returned if `sass.compile()` produces results that differ from those found in the committed `.css` files. Intended only for use as a CI safeguard.')
+            'When set to true, no `.css` outputs will be written to disk, \nand a non-zero exit code will be returned if `sass.compile()` \nproduces results that differ from those found in the committed \n`.css` files. \nIntended only for use as a CI safeguard.')
     ..addFlag(helpFlag,
         abbr: 'h',
-        defaultsTo: false,
         negatable: false,
         help: 'Prints usage instructions to the terminal.');
 

--- a/lib/src/bin/compile_sass.dart
+++ b/lib/src/bin/compile_sass.dart
@@ -317,10 +317,16 @@ void compileSass(SassCompilationOptions options,
     for (var target in compileTargets) {
       try {
         final singleCompileTimer = new Stopwatch()..start();
+        final outputSubDir = target.substring(
+            options.sourceDir.length, target.indexOf(path.basename(target)));
+        var outputDir = options.outputDir;
+        if (outputSubDir.isNotEmpty) {
+          outputDir = path.join(outputDir, outputSubDir);
+        }
 
         SingleMapping sourceMap;
         var cssPath = path.setExtension(
-            path.join(options.outputDir, path.basename(target)),
+            path.join(outputDir, path.basename(target)),
             outputStyleArgToOutputStyleFileExtension[style]);
         var cssSrc = sass.compile(target,
             style: outputStyle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   args: ^1.5.1
+  async: ">=1.13.3 <3.0.0"
   colorize: <3.0.0
   dart2_constant: ^1.0.0
   glob: ^1.1.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
 
 dependencies:
   args: ^1.5.1
+  colorize: <3.0.0
   dart2_constant: ^1.0.0
   glob: ^1.1.7
   intl: ">=0.14.0 <0.16.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   args: ^1.5.1
   async: ">=1.13.3 <3.0.0"
-  colorize: <3.0.0
+  colorize: ">=0.1.2 <3.0.0"
   dart2_constant: ^1.0.0
   glob: ^1.1.7
   intl: ">=0.14.0 <0.16.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,8 @@ dependencies:
   package_config: ^1.0.3
   path: ^1.5.1
   sass: ^1.6.0 # NOTE: Need 1.18.0 when using Dart 2 SDK
-  source_maps: ^0.10.5 # allow the version constraint within the sass package determine this since it is pre-1.0.0
+  source_maps: ^0.10.5
+  watcher: ^0.9.6
 
 dev_dependencies:
   build_runner: ">=0.6.0 <1.0.0"

--- a/test/unit/vm/compile_sass_test.dart
+++ b/test/unit/vm/compile_sass_test.dart
@@ -150,39 +150,60 @@ void main() {
 
         group('(compressed)', () {
           group('when the --outputStyle argument contains both styles', () {
-            test('and the --compressedOutputStyleFileExtension argument is set',
+            group(
+                'and the --compressedOutputStyleFileExtension argument is set',
                 () {
-              compiler.main([
-                '--sourceDir',
-                defaultSourceDir,
-                '--outputStyle',
-                'expanded,compressed',
-                '--compressedOutputStyleFileExtension',
-                '.min.foo.css',
-              ]);
+              test(
+                  'to something that does not match --compressedOutputStyleFileExtension',
+                  () async {
+                await compiler.main([
+                  '--sourceDir',
+                  defaultSourceDir,
+                  '--outputStyle',
+                  'expanded,compressed',
+                  '--compressedOutputStyleFileExtension',
+                  '.min.foo.css',
+                ]);
 
-              expect(
-                  new File(path.join(defaultSourceDir, 'test.min.foo.css'))
-                      .existsSync(),
-                  isFalse,
-                  reason:
-                      'The file extension for compressed output should not be customizable when both '
-                      'outputStyle values are specified');
-              expect(
-                  new File(path.join(defaultSourceDir, 'test.min.foo.css.map'))
-                      .existsSync(),
-                  isFalse,
-                  reason:
-                      'The file extension for compressed output should not be customizable when both '
-                      'outputStyle values are specified');
-              expect(
-                  new File(path.join(defaultSourceDir, 'test.min.css'))
-                      .existsSync(),
-                  isTrue);
-              expect(
-                  new File(path.join(defaultSourceDir, 'test.min.css.map'))
-                      .existsSync(),
-                  isTrue);
+                expect(
+                    new File(path.join(defaultSourceDir, 'test.min.foo.css'))
+                        .existsSync(),
+                    isTrue);
+                expect(
+                    new File(
+                            path.join(defaultSourceDir, 'test.min.foo.css.map'))
+                        .existsSync(),
+                    isTrue);
+              });
+
+              test(
+                  'to something that matches --compressedOutputStyleFileExtension',
+                  () async {
+                await compiler.main([
+                  '--sourceDir',
+                  defaultSourceDir,
+                  '--outputStyle',
+                  'expanded,compressed',
+                  '--compressedOutputStyleFileExtension',
+                  '.foo.css',
+                  '--expandedOutputStyleFileExtension',
+                  '.foo.css',
+                ]);
+
+                expect(exitCode, 1);
+                expect(
+                    new File(path.join(defaultSourceDir, 'test.foo.css'))
+                        .existsSync(),
+                    isFalse,
+                    reason:
+                        'The file extension for compressed output cannot match the one for expanded output');
+                expect(
+                    new File(path.join(defaultSourceDir, 'test.foo.css.map'))
+                        .existsSync(),
+                    isFalse,
+                    reason:
+                        'The file extension for compressed output cannot match the one for expanded output');
+              });
             });
           });
 

--- a/test/unit/vm/compile_sass_test.dart
+++ b/test/unit/vm/compile_sass_test.dart
@@ -25,6 +25,10 @@ void main() {
     const defaultSourceDir = 'test/unit/vm/fixtures/sass/';
     const specificOutputDir = 'test/unit/vm/fixtures/css/';
 
+    setUp(() {
+      exitCode = 0;
+    });
+
     tearDown(() {
       final compiledCssFiles =
           new Glob('$defaultSourceDir**.css', recursive: true).listSync();
@@ -50,15 +54,16 @@ void main() {
       }
     });
 
-    test('runs successfully', () {
-      expect(() => compiler.main(['--sourceDir', defaultSourceDir]),
-          returnsNormally);
+    test('runs successfully', () async {
+      await compiler.main(['--sourceDir', defaultSourceDir]);
+
+      expect(exitCode, 0);
     });
 
     group('generates .css / .css.map file(s)', () {
       group('in the expected directory', () {
-        test('by default', () {
-          compiler.main(['--sourceDir', defaultSourceDir]);
+        test('by default', () async {
+          await compiler.main(['--sourceDir', defaultSourceDir]);
 
           expect(new File(path.join(defaultSourceDir, 'test.css')).existsSync(),
               isTrue);
@@ -68,8 +73,8 @@ void main() {
               isTrue);
         });
 
-        test('when the --outputDir argument is specified', () {
-          compiler.main([
+        test('when the --outputDir argument is specified', () async {
+          await compiler.main([
             '--sourceDir',
             defaultSourceDir,
             '--outputDir',
@@ -93,8 +98,8 @@ void main() {
       });
 
       group('with the expected file names', () {
-        test('when the --outputStyle argument contains both styles', () {
-          compiler.main([
+        test('when the --outputStyle argument contains both styles', () async {
+          await compiler.main([
             '--sourceDir',
             defaultSourceDir,
             '--outputStyle',
@@ -117,8 +122,8 @@ void main() {
               isTrue);
         });
 
-        test('when there are multiple --outputStyle arguments', () {
-          compiler.main([
+        test('when there are multiple --outputStyle arguments', () async {
+          await compiler.main([
             '--sourceDir',
             defaultSourceDir,
             '--outputStyle',
@@ -183,8 +188,8 @@ void main() {
 
           group('when the --outputStyle argument contains only "compressed"',
               () {
-            test('', () {
-              compiler.main([
+            test('', () async {
+              await compiler.main([
                 '--sourceDir',
                 defaultSourceDir,
                 '--outputStyle',
@@ -203,8 +208,8 @@ void main() {
 
             test(
                 'and the --compressedOutputStyleFileExtension argument is specified',
-                () {
-              compiler.main([
+                () async {
+              await compiler.main([
                 '--sourceDir',
                 defaultSourceDir,
                 '--outputStyle',
@@ -236,8 +241,8 @@ void main() {
         group('(expanded)', () {
           group('when the --outputStyle argument contains both styles', () {
             test('and the --expandedOutputStyleFileExtension argument is set',
-                () {
-              compiler.main([
+                () async {
+              await compiler.main([
                 '--sourceDir',
                 defaultSourceDir,
                 '--outputStyle',
@@ -272,8 +277,8 @@ void main() {
           });
 
           group('when the --outputStyle argument contains only "expanded"', () {
-            test('', () {
-              compiler.main([
+            test('', () async {
+              await compiler.main([
                 '--sourceDir',
                 defaultSourceDir,
                 '--outputStyle',
@@ -292,8 +297,8 @@ void main() {
 
             test(
                 'and the --expandedOutputStyleFileExtension argument is specified',
-                () {
-              compiler.main([
+                () async {
+              await compiler.main([
                 '--sourceDir',
                 defaultSourceDir,
                 '--outputStyle',
@@ -329,8 +334,8 @@ void main() {
         });
       });
 
-      test('with the expected CSS output', () {
-        compiler.main(['--sourceDir', defaultSourceDir]);
+      test('with the expected CSS output', () async {
+        await compiler.main(['--sourceDir', defaultSourceDir]);
 
         final content = new File(path.join(defaultSourceDir, 'test.css'))
             .readAsStringSync();
@@ -340,8 +345,8 @@ void main() {
       });
 
       group('with the expected source map pathing', () {
-        test('when the --outputDir is the same as the --sourceDir', () {
-          compiler.main(['--sourceDir', defaultSourceDir]);
+        test('when the --outputDir is the same as the --sourceDir', () async {
+          await compiler.main(['--sourceDir', defaultSourceDir]);
           final cssContent = new File(path.join(defaultSourceDir, 'test.css'))
               .readAsStringSync();
           final sourceMapContent =
@@ -352,8 +357,9 @@ void main() {
           expect(sourceMapContent, contains('"sourceRoot":""'));
         });
 
-        test('when the --outputDir is the different than the --sourceDir', () {
-          compiler.main([
+        test('when the --outputDir is the different than the --sourceDir',
+            () async {
+          await compiler.main([
             '--sourceDir',
             defaultSourceDir,
             '--outputDir',

--- a/test/unit/vm/compile_sass_test.dart
+++ b/test/unit/vm/compile_sass_test.dart
@@ -23,6 +23,8 @@ import 'package:w_common/src/bin/compile_sass.dart' as compiler;
 void main() {
   group('pub run w_common:compile_sass', () {
     const defaultSourceDir = 'test/unit/vm/fixtures/sass/';
+    const nestedSourceDirName = 'nested_directory';
+    const defaultNestedSourceDir = '$defaultSourceDir$nestedSourceDirName/';
     const specificOutputDir = 'test/unit/vm/fixtures/css/';
 
     setUp(() {
@@ -62,38 +64,88 @@ void main() {
 
     group('generates .css / .css.map file(s)', () {
       group('in the expected directory', () {
-        test('by default', () async {
-          await compiler.main(['--sourceDir', defaultSourceDir]);
+        group('by default', () {
+          setUp(() async {
+            await compiler.main(['--sourceDir', defaultSourceDir]);
+          });
 
-          expect(new File(path.join(defaultSourceDir, 'test.css')).existsSync(),
-              isTrue);
-          expect(
-              new File(path.join(defaultSourceDir, 'test.css.map'))
-                  .existsSync(),
-              isTrue);
+          test('when the source is in the root of the sourceDir', () {
+            final expectedCssFile =
+                new File(path.join(defaultSourceDir, 'test.css'));
+            expect(expectedCssFile.existsSync(), isTrue,
+                reason: '$expectedCssFile does not exist.');
+
+            final expectedCssMapFile =
+                new File(path.join(defaultSourceDir, 'test.css.map'));
+            expect(expectedCssMapFile.existsSync(), isTrue,
+                reason: '$expectedCssMapFile does not exist.');
+          });
+
+          test(
+              'when the source is in a subdirectory of the root of the sourceDir',
+              () {
+            final expectedCssFile =
+                new File(path.join(defaultNestedSourceDir, 'nested_test.css'));
+            expect(expectedCssFile.existsSync(), isTrue,
+                reason: '$expectedCssFile does not exist.');
+
+            final expectedCssMapFile = new File(
+                path.join(defaultNestedSourceDir, 'nested_test.css.map'));
+            expect(expectedCssMapFile.existsSync(), isTrue,
+                reason: '$expectedCssMapFile does not exist.');
+          });
         });
 
-        test('when the --outputDir argument is specified', () async {
-          await compiler.main([
-            '--sourceDir',
-            defaultSourceDir,
-            '--outputDir',
-            specificOutputDir,
-          ]);
+        group('when the --outputDir argument is specified', () {
+          setUp(() async {
+            await compiler.main([
+              '--sourceDir',
+              defaultSourceDir,
+              '--outputDir',
+              specificOutputDir,
+            ]);
+          });
 
-          expect(new File(path.join(defaultSourceDir, 'test.css')).existsSync(),
-              isFalse);
-          expect(
-              new File(path.join(defaultSourceDir, 'test.css.map'))
-                  .existsSync(),
-              isFalse);
-          expect(
-              new File(path.join(specificOutputDir, 'test.css')).existsSync(),
-              isTrue);
-          expect(
-              new File(path.join(specificOutputDir, 'test.css.map'))
-                  .existsSync(),
-              isTrue);
+          test('when the source is in the root of the sourceDir', () {
+            expect(
+                new File(path.join(defaultSourceDir, 'test.css')).existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(defaultSourceDir, 'test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(specificOutputDir, 'test.css')).existsSync(),
+                isTrue);
+            expect(
+                new File(path.join(specificOutputDir, 'test.css.map'))
+                    .existsSync(),
+                isTrue);
+          });
+
+          test(
+              'when the source is in a subdirectory of the root of the sourceDir',
+              () {
+            expect(
+                new File(path.join(defaultNestedSourceDir, 'nested_test.css'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(
+                        defaultNestedSourceDir, 'nested_test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(specificOutputDir,
+                        '$nestedSourceDirName/nested_test.css'))
+                    .existsSync(),
+                isTrue);
+            expect(
+                new File(path.join(specificOutputDir,
+                        '$nestedSourceDirName/nested_test.css.map'))
+                    .existsSync(),
+                isTrue);
+          });
         });
       });
 
@@ -366,41 +418,90 @@ void main() {
       });
 
       group('with the expected source map pathing', () {
-        test('when the --outputDir is the same as the --sourceDir', () async {
-          await compiler.main(['--sourceDir', defaultSourceDir]);
-          final cssContent = new File(path.join(defaultSourceDir, 'test.css'))
-              .readAsStringSync();
-          final sourceMapContent =
-              new File(path.join(defaultSourceDir, 'test.css.map'))
-                  .readAsStringSync();
+        group('when the --outputDir is the same as the --sourceDir', () {
+          setUp(() async {
+            await compiler.main(['--sourceDir', defaultSourceDir]);
+          });
 
-          expect(cssContent, endsWith('/*# sourceMappingURL=test.css.map */'));
-          expect(sourceMapContent, contains('"sourceRoot":""'));
+          test('and the source is in the root of the sourceDir', () {
+            final cssContent = new File(path.join(defaultSourceDir, 'test.css'))
+                .readAsStringSync();
+            final sourceMapContent =
+                new File(path.join(defaultSourceDir, 'test.css.map'))
+                    .readAsStringSync();
+
+            expect(
+                cssContent, endsWith('/*# sourceMappingURL=test.css.map */'));
+            expect(sourceMapContent, contains('"sourceRoot":""'));
+          });
+
+          test(
+              'and the source is in a subdirectory of the root of the sourceDir',
+              () {
+            final cssContent =
+                new File(path.join(defaultNestedSourceDir, 'nested_test.css'))
+                    .readAsStringSync();
+            final sourceMapContent = new File(
+                    path.join(defaultNestedSourceDir, 'nested_test.css.map'))
+                .readAsStringSync();
+
+            expect(cssContent,
+                endsWith('/*# sourceMappingURL=nested_test.css.map */'));
+            expect(sourceMapContent, contains('"sourceRoot":""'));
+          });
         });
 
-        test('when the --outputDir is the different than the --sourceDir',
-            () async {
-          await compiler.main([
-            '--sourceDir',
-            defaultSourceDir,
-            '--outputDir',
-            specificOutputDir,
-          ]);
-          final cssTarget = new File(path.join(specificOutputDir, 'test.css'));
-          final cssContent = cssTarget.readAsStringSync();
-          final sourceMapContent =
-              new File(path.join(specificOutputDir, 'test.css.map'))
-                  .readAsStringSync();
+        group('when the --outputDir is the different than the --sourceDir', () {
+          setUp(() async {
+            await compiler.main([
+              '--sourceDir',
+              defaultSourceDir,
+              '--outputDir',
+              specificOutputDir,
+            ]);
+          });
 
-          expect(cssContent, endsWith('/*# sourceMappingURL=test.css.map */'));
+          test('and the source is in the root of the sourceDir', () {
+            final cssTarget =
+                new File(path.join(specificOutputDir, 'test.css'));
+            final cssContent = cssTarget.readAsStringSync();
+            final sourceMapContent =
+                new File(path.join(specificOutputDir, 'test.css.map'))
+                    .readAsStringSync();
 
-          final relativePathToSassFileFromCompiledCss = path.dirname(
-              path.relative(path.join(defaultSourceDir, 'test.scss'),
-                  from: cssTarget.path));
-          expect(
-              sourceMapContent,
-              contains(
-                  '"sourceRoot":"$relativePathToSassFileFromCompiledCss"'));
+            expect(
+                cssContent, endsWith('/*# sourceMappingURL=test.css.map */'));
+
+            final relativePathToSassFileFromCompiledCss = path.dirname(
+                path.relative(path.join(defaultSourceDir, 'test.scss'),
+                    from: cssTarget.path));
+            expect(
+                sourceMapContent,
+                contains(
+                    '"sourceRoot":"$relativePathToSassFileFromCompiledCss"'));
+          });
+
+          test(
+              'and the source is in a subdirectory of the root of the sourceDir',
+              () {
+            final cssTarget = new File(path.join(
+                specificOutputDir, '$nestedSourceDirName/nested_test.css'));
+            final cssContent = cssTarget.readAsStringSync();
+            final sourceMapContent = new File(path.join(specificOutputDir,
+                    '$nestedSourceDirName/nested_test.css.map'))
+                .readAsStringSync();
+
+            expect(cssContent,
+                endsWith('/*# sourceMappingURL=nested_test.css.map */'));
+
+            final relativePathToSassFileFromCompiledCss = path.dirname(path
+                .relative(path.join(defaultNestedSourceDir, 'nested_test.scss'),
+                    from: cssTarget.path));
+            expect(
+                sourceMapContent,
+                contains(
+                    '"sourceRoot":"$relativePathToSassFileFromCompiledCss"'));
+          });
         });
       });
     });

--- a/test/unit/vm/fixtures/sass/nested_directory/nested_test.scss
+++ b/test/unit/vm/fixtures/sass/nested_directory/nested_test.scss
@@ -1,0 +1,6 @@
+.selector1 {
+  color: black;
+}
+
+@import 'package:w_common/src/test_fixtures/sass/test_package_import';
+@import '../relative_import';


### PR DESCRIPTION
# [CPLAT-5536](https://jira.atl.workiva.net/browse/CPLAT-5536)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-5536)

## Motivation
The new [`compile_sass`](https://github.com/Workiva/w_common/pull/116) script does not have an option to run it as a watcher that recompiles sass files on every change.

## Changes
1. Added a `--watch` flag
2. Improved output of `--help`
3. Added a utility class to make passing around common CLI options to multiple functions less verbose
4. Added color to the output of the script
5. Compressed output file extensions can now be customized when more than one `outputStyle` is set, as long as it doesn't match the extension used for the file extension used for the "expanded" one.

#### Release Notes
Add --watch option to compile_sass script

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: @greglittlefield-wf @corwinsheahan-wf @evanweible-wf @kealjones-wk @joebingham-wk 

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - Publink this branch to your local copy of `wdesk_sdk`
        - Run `pub run w_common:compile_sass --sourceDir lib/ --watch` from the root of your local copy of `wdesk_sdk`
        - Verify that it compiles the CSS files as expected when first starting up
        - Make a __valid__ change to any `.scss` file that starts with an `_`, and verify that it recompiles all the top-level `.scss` files.
        - Make a __valid__ change to any top level `.scss` file (one that does not start with an `_`), and verify that it only recompiles that one top-level `.scss` file.
        - Make an __invalid__ change to any `.scss` file, and verify that communicates that an error has occurred, prints the stacktrace from the sass compiler, and continues to watch for changes.
            - Revert your __invalid__ change, and verify that it once again compiles all the `.scss` files with no errors, and continues to watch for changes.
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
