### PR TITLE
Add trailing slashes to sourceDir / outputDir

### DIFF
--- a/lib/src/bin/compile_sass.dart
+++ b/lib/src/bin/compile_sass.dart
@@ -47,7 +47,6 @@ const Map<String, sass.OutputStyle> outputStyleArgToOutputStyleValue = const {
 
 class SassCompilationOptions {
   final List<String> unparsedArgs;
-  final String outputDir;
   final String expandedOutputStyleFileExtension;
   final List<String> outputStyles;
   final bool watch;
@@ -55,7 +54,7 @@ class SassCompilationOptions {
 
   SassCompilationOptions({
     @required this.unparsedArgs,
-    @required this.outputDir,
+    @required String outputDir,
     String sourceDir,
     String compressedOutputStyleFileExtension,
     this.expandedOutputStyleFileExtension =
@@ -103,6 +102,15 @@ class SassCompilationOptions {
     }
 
     _watchDirs = [_sourceDir]..addAll(watchDirs);
+
+    if (!_sourceDir.endsWith('/')) {
+      _sourceDir = '$_sourceDir/';
+    }
+
+    _outputDir = outputDir;
+    if (!_outputDir.endsWith('/')) {
+      _outputDir = '$_outputDir/';
+    }
   }
 
   List<String> get watchDirs => _watchDirs;
@@ -110,6 +118,9 @@ class SassCompilationOptions {
 
   String get sourceDir => _sourceDir;
   String _sourceDir;
+
+  String get outputDir => _outputDir;
+  String _outputDir;
 
   String get compressedOutputStyleFileExtension =>
       _compressedOutputStyleFileExtension;

--- a/test/unit/vm/compile_sass_test.dart
+++ b/test/unit/vm/compile_sass_test.dart
@@ -100,17 +100,18 @@ void main() {
 
         group('when the --sourceDir argument has no trailing slash', () {
           setUp(() async {
-            await compiler.main(['--sourceDir', defaultSourceDirWithoutTrailingSlash]);
+            await compiler
+                .main(['--sourceDir', defaultSourceDirWithoutTrailingSlash]);
           });
 
           test('when the source is in the root of the sourceDir', () {
-            final expectedCssFile =
-                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css'));
+            final expectedCssFile = new File(
+                path.join(defaultSourceDirWithoutTrailingSlash, 'test.css'));
             expect(expectedCssFile.existsSync(), isTrue,
                 reason: '$expectedCssFile does not exist.');
 
-            final expectedCssMapFile =
-                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css.map'));
+            final expectedCssMapFile = new File(path.join(
+                defaultSourceDirWithoutTrailingSlash, 'test.css.map'));
             expect(expectedCssMapFile.existsSync(), isTrue,
                 reason: '$expectedCssMapFile does not exist.');
           });
@@ -182,7 +183,9 @@ void main() {
           });
         });
 
-        group('when the --outputDir argument is specified and the --sourceDir argument has no trailing slash', () {
+        group(
+            'when the --outputDir argument is specified and the --sourceDir argument has no trailing slash',
+            () {
           setUp(() async {
             await compiler.main([
               '--sourceDir',
@@ -194,10 +197,13 @@ void main() {
 
           test('when the source is in the root of the sourceDir', () {
             expect(
-                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css')).existsSync(),
+                new File(path.join(
+                        defaultSourceDirWithoutTrailingSlash, 'test.css'))
+                    .existsSync(),
                 isFalse);
             expect(
-                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css.map'))
+                new File(path.join(
+                        defaultSourceDirWithoutTrailingSlash, 'test.css.map'))
                     .existsSync(),
                 isFalse);
             expect(
@@ -234,7 +240,9 @@ void main() {
           });
         });
 
-        group('when both the --outputDir and --sourceDir arguments have no trailing slash', () {
+        group(
+            'when both the --outputDir and --sourceDir arguments have no trailing slash',
+            () {
           setUp(() async {
             await compiler.main([
               '--sourceDir',
@@ -246,17 +254,23 @@ void main() {
 
           test('when the source is in the root of the sourceDir', () {
             expect(
-                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css')).existsSync(),
-                isFalse);
-            expect(
-                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css.map'))
+                new File(path.join(
+                        defaultSourceDirWithoutTrailingSlash, 'test.css'))
                     .existsSync(),
                 isFalse);
             expect(
-                new File(path.join(specificOutputDirWithoutTrailingSlash, 'test.css')).existsSync(),
+                new File(path.join(
+                        defaultSourceDirWithoutTrailingSlash, 'test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(
+                        specificOutputDirWithoutTrailingSlash, 'test.css'))
+                    .existsSync(),
                 isTrue);
             expect(
-                new File(path.join(specificOutputDirWithoutTrailingSlash, 'test.css.map'))
+                new File(path.join(
+                        specificOutputDirWithoutTrailingSlash, 'test.css.map'))
                     .existsSync(),
                 isTrue);
           });

--- a/test/unit/vm/compile_sass_test.dart
+++ b/test/unit/vm/compile_sass_test.dart
@@ -22,10 +22,12 @@ import 'package:w_common/src/bin/compile_sass.dart' as compiler;
 
 void main() {
   group('pub run w_common:compile_sass', () {
-    const defaultSourceDir = 'test/unit/vm/fixtures/sass/';
+    const defaultSourceDirWithoutTrailingSlash = 'test/unit/vm/fixtures/sass';
+    const defaultSourceDir = '$defaultSourceDirWithoutTrailingSlash/';
     const nestedSourceDirName = 'nested_directory';
     const defaultNestedSourceDir = '$defaultSourceDir$nestedSourceDirName/';
-    const specificOutputDir = 'test/unit/vm/fixtures/css/';
+    const specificOutputDirWithoutTrailingSlash = 'test/unit/vm/fixtures/css';
+    const specificOutputDir = '$specificOutputDirWithoutTrailingSlash/';
 
     setUp(() {
       exitCode = 0;
@@ -96,6 +98,38 @@ void main() {
           });
         });
 
+        group('when the --sourceDir argument has no trailing slash', () {
+          setUp(() async {
+            await compiler.main(['--sourceDir', defaultSourceDirWithoutTrailingSlash]);
+          });
+
+          test('when the source is in the root of the sourceDir', () {
+            final expectedCssFile =
+                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css'));
+            expect(expectedCssFile.existsSync(), isTrue,
+                reason: '$expectedCssFile does not exist.');
+
+            final expectedCssMapFile =
+                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css.map'));
+            expect(expectedCssMapFile.existsSync(), isTrue,
+                reason: '$expectedCssMapFile does not exist.');
+          });
+
+          test(
+              'when the source is in a subdirectory of the root of the sourceDir',
+              () {
+            final expectedCssFile =
+                new File(path.join(defaultNestedSourceDir, 'nested_test.css'));
+            expect(expectedCssFile.existsSync(), isTrue,
+                reason: '$expectedCssFile does not exist.');
+
+            final expectedCssMapFile = new File(
+                path.join(defaultNestedSourceDir, 'nested_test.css.map'));
+            expect(expectedCssMapFile.existsSync(), isTrue,
+                reason: '$expectedCssMapFile does not exist.');
+          });
+        });
+
         group('when the --outputDir argument is specified', () {
           setUp(() async {
             await compiler.main([
@@ -142,6 +176,110 @@ void main() {
                 isTrue);
             expect(
                 new File(path.join(specificOutputDir,
+                        '$nestedSourceDirName/nested_test.css.map'))
+                    .existsSync(),
+                isTrue);
+          });
+        });
+
+        group('when the --outputDir argument is specified and the --sourceDir argument has no trailing slash', () {
+          setUp(() async {
+            await compiler.main([
+              '--sourceDir',
+              defaultSourceDirWithoutTrailingSlash,
+              '--outputDir',
+              specificOutputDir,
+            ]);
+          });
+
+          test('when the source is in the root of the sourceDir', () {
+            expect(
+                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css')).existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(specificOutputDir, 'test.css')).existsSync(),
+                isTrue);
+            expect(
+                new File(path.join(specificOutputDir, 'test.css.map'))
+                    .existsSync(),
+                isTrue);
+          });
+
+          test(
+              'when the source is in a subdirectory of the root of the sourceDir',
+              () {
+            expect(
+                new File(path.join(defaultNestedSourceDir, 'nested_test.css'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(
+                        defaultNestedSourceDir, 'nested_test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(specificOutputDir,
+                        '$nestedSourceDirName/nested_test.css'))
+                    .existsSync(),
+                isTrue);
+            expect(
+                new File(path.join(specificOutputDir,
+                        '$nestedSourceDirName/nested_test.css.map'))
+                    .existsSync(),
+                isTrue);
+          });
+        });
+
+        group('when both the --outputDir and --sourceDir arguments have no trailing slash', () {
+          setUp(() async {
+            await compiler.main([
+              '--sourceDir',
+              defaultSourceDirWithoutTrailingSlash,
+              '--outputDir',
+              specificOutputDirWithoutTrailingSlash,
+            ]);
+          });
+
+          test('when the source is in the root of the sourceDir', () {
+            expect(
+                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css')).existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(defaultSourceDirWithoutTrailingSlash, 'test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(specificOutputDirWithoutTrailingSlash, 'test.css')).existsSync(),
+                isTrue);
+            expect(
+                new File(path.join(specificOutputDirWithoutTrailingSlash, 'test.css.map'))
+                    .existsSync(),
+                isTrue);
+          });
+
+          test(
+              'when the source is in a subdirectory of the root of the sourceDir',
+              () {
+            expect(
+                new File(path.join(defaultNestedSourceDir, 'nested_test.css'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(
+                        defaultNestedSourceDir, 'nested_test.css.map'))
+                    .existsSync(),
+                isFalse);
+            expect(
+                new File(path.join(specificOutputDirWithoutTrailingSlash,
+                        '$nestedSourceDirName/nested_test.css'))
+                    .existsSync(),
+                isTrue);
+            expect(
+                new File(path.join(specificOutputDirWithoutTrailingSlash,
                         '$nestedSourceDirName/nested_test.css.map'))
                     .existsSync(),
                 isTrue);


### PR DESCRIPTION
## Motivation
#119 introduced a regression for consumers that were not providing a trailing slash when specifying `--sourceDir` or `--outputDir` arguments.

## Changes
1. Tack on a trailing slash in the constructor for either argument if one was not provided to ensure accurate "sub directory" inference later on.
2. Add tests.

#### Release Notes
Fix an issue with the compile_sass script that caused it to fail when no trailing slash was present on the `--sourceDir` or `--outputDir` arguments.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        - [ ] Passing CI
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
