### PR TITLE
CPLAT-6848: Add disposable type name(s)

### DIFF
--- a/example/disposable/example.dart
+++ b/example/disposable/example.dart
@@ -5,6 +5,9 @@ import 'package:logging/logging.dart';
 import 'package:w_common/disposable.dart';
 
 class TreeNode extends Disposable {
+  @override
+  String get disposableTypeName => 'TreeNode';
+
   TreeNode(int depth, int childCount) {
     manageStreamController(new StreamController.broadcast());
     listenToStream(document.onDoubleClick, _onDoubleClick);

--- a/lib/src/browser/disposable_browser.dart
+++ b/lib/src/browser/disposable_browser.dart
@@ -22,6 +22,9 @@ import 'package:w_common/func.dart';
 import 'package:w_common/src/common/disposable.dart' as disposable_common;
 
 class _InnerDisposable extends disposable_common.Disposable {
+  @override
+  String get disposableTypeName => '_InnerDisposable';
+
   Func<Future<Null>> onDisposeHandler;
   Func<Future<Null>> onWillDisposeHandler;
 

--- a/lib/src/common/cache/cache.dart
+++ b/lib/src/common/cache/cache.dart
@@ -94,6 +94,9 @@ class CachingStrategy<TIdentifier, TValue> {
 /// References are retained for the lifecycle of the instance of the [Cache],
 /// unless explicitly removed.
 class Cache<TIdentifier, TValue> extends Object with Disposable {
+  @override
+  String get disposableTypeName => 'Cache';
+
   final Logger _log = new Logger('w_common.Cache');
 
   /// Any apply to item callbacks currently in flight.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,9 +25,9 @@ dependencies:
   watcher: ^0.9.6
 
 dev_dependencies:
-  build_runner: ">=0.6.0 <1.0.0"
-  build_test: ">=0.9.0 <1.0.0"
-  build_web_compilers: ">=0.2.0 <1.0.0"
+  build_runner: ">=0.6.0 <2.0.0"
+  build_test: ">=0.9.0 <2.0.0"
+  build_web_compilers: ">=0.2.0 <3.0.0"
   dependency_validator: ^1.2.2
   mockito: '>=2.2.2 < 4.0.0'
   test: '>=0.12.34 <2.0.0'

--- a/test/unit/browser/browser_stubs.dart
+++ b/test/unit/browser/browser_stubs.dart
@@ -19,6 +19,9 @@ import 'package:w_common/disposable_browser.dart';
 
 import '../stubs.dart';
 
-class BrowserDisposable extends Object with Disposable, StubDisposable {}
+class BrowserDisposable extends Object with Disposable, StubDisposable {
+  @override
+  String get disposableTypeName => 'BrowserDisposable';
+}
 
 class MockEventTarget extends Mock implements EventTarget {}

--- a/test/unit/stubs.dart
+++ b/test/unit/stubs.dart
@@ -65,6 +65,9 @@ abstract class StubDisposable implements Disposable {
 }
 
 class DisposeCounter extends Disposable {
+  @override
+  String get disposableTypeName => 'DisposeCounter';
+
   int disposeCount = 0;
   @override
   Future<Null> dispose() {

--- a/test/unit/vm/test_utils_test.dart
+++ b/test/unit/vm/test_utils_test.dart
@@ -42,7 +42,4 @@ class MatchClass<T> extends Disposable {
   String get disposableTypeName => 'MatchClass';
 }
 
-class MismatchClass<T> extends Disposable {
-  @override
-  String get disposableTypeName => 'MismatchClass';
-}
+class MismatchClass<T> extends Disposable {}

--- a/test/unit/vm/test_utils_test.dart
+++ b/test/unit/vm/test_utils_test.dart
@@ -42,4 +42,7 @@ class MatchClass<T> extends Disposable {
   String get disposableTypeName => 'MatchClass';
 }
 
-class MismatchClass<T> extends Disposable {}
+class MismatchClass<T> extends Disposable {
+  @override
+  String get disposableTypeName => 'MismatchClass';
+}

--- a/test/unit/vm/vm_stubs.dart
+++ b/test/unit/vm/vm_stubs.dart
@@ -16,4 +16,7 @@ import 'package:w_common/disposable.dart';
 
 import '../stubs.dart';
 
-class VMDisposable extends Object with Disposable, StubDisposable {}
+class VMDisposable extends Object with Disposable, StubDisposable {
+  @override
+  String get disposableTypeName => 'VMDisposable';
+}


### PR DESCRIPTION
Some of the classes that extend or mixin `Disposable` missing `disposableTypeName` override.
     This PR will add missing overrides, where it's necessary