### PR TITLE
XL-8675 Add cancelable futures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ addons:
 
 jobs:
   include:
-    - dart: 2.4.0
-      name: "SDK: 2.4.0"
+    - dart: 2.6.1
+      name: "SDK: 2.6.1"
       script:
         - dartanalyzer .
         - pub run test

--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -29,4 +29,4 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV7,
         ObjectDisposedException;
 export 'package:w_common/src/common/disposable.dart'
-    show Disposable, Disposer, ManagedDisposer;
+    show Disposable, Disposer, ManagedDisposer, DisposeCanceller;

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -744,7 +744,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
 }
 
 extension DisposeCanceller<T> on Future<T> {
-  Future<T> cancelWithDispose(Disposable disposable) {
+  Future<T> cancelOnDisposeOf(Disposable disposable) {
     // Wrap this Future in CancelableOperation to make it "cancelable"
     final op = CancelableOperation.fromFuture(this);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://www.github.com/Workiva/w_common
 
 environment:
-  sdk: '>=2.4.0 <3.0.0'
+  sdk: '>=2.6.1 <3.0.0'
 
 dependencies:
   args: ^1.5.2

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -1048,6 +1048,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
       await disposable.dispose();
       await asyncTaskCompleter.future;
+      await Future<Null>.value(); // Allow for the event loop to clear.
     });
 
     test('does execute code after an await if disposable does not dispose',

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -1037,7 +1037,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         () async {
       final asyncTaskCompleter = Completer<void>();
       Future<void> _asyncTask() async {
-        await Future<void>.delayed(Duration(milliseconds: 5));
+        await Future<void>.delayed(Duration(milliseconds: 30));
         asyncTaskCompleter.complete();
       }
 
@@ -1054,7 +1054,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
         () async {
       final asyncTaskCompleter = Completer<void>();
       Future<void> _asyncTask() async {
-        await Future<void>.delayed(Duration(milliseconds: 5));
+        await Future<void>.delayed(Duration(milliseconds: 30));
         asyncTaskCompleter.complete();
       }
 

--- a/test/unit/disposable_common.dart
+++ b/test/unit/disposable_common.dart
@@ -1040,9 +1040,9 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       }
 
       // Start an asynchronous task, dispose the disposable before it finishes.
-      final future = _asyncTask().cancelWithDispose(disposable);
-
-      future.then((_) => fail('This future should not have resolved.'));
+      _asyncTask()
+          .cancelOnDisposeOf(disposable)
+          .then((_) => fail('This future should not have resolved.'));
 
       await disposable.dispose();
       await Future<void>.delayed(Duration(milliseconds: 12));
@@ -1055,7 +1055,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       }
 
       final completer = Completer<dynamic>();
-      await _asyncTask().cancelWithDispose(disposable).then(completer.complete);
+      await _asyncTask().cancelWithDisposeOf(disposable).then(completer.complete);
       await completer.future;
     });
   });


### PR DESCRIPTION
## Motivation
- `Disposable`s whose operations perform long-running `await`s must add guards against disposals, either in the form of `isOrWillBeDisposed` checks or by wrapping logic in `awaitBeforeDispose(...)`
- It would be convenient if some `await`s just never returned if the Disposable was disposed before the Future's completion.

## Changes
- Bump minimum SDK requirements to v2.6.1
- Leverage Dart 2.6.1's extensions to decorate a given Future to be "cancelable"
  - cancelled when a given Disposable has `dispose()` called on it.
  - when cancelled, code awaiting the Future will not be executed
- allow for implementers of Disposables to do things like:
```dart
await _fetchData().cancelOnDisposeOf(this);
// later code will never be reached if `this` disposes during the await
```

#### Release Notes
- Add a method to instances of Future that cause awaiters of the instance to be forgone if the provided Disposable is disposed.

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: @Workiva/xl

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
