### PR TITLE
Log on invalid calls

### DIFF
--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -713,35 +713,43 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     }
   }
 
-  void _logOnInvalidCall(
+  void _assertAndLogOnInvalidCall(
       String methodName, String parameterName, dynamic parameterValue) {
     if (parameterValue == null) {
-      _logger.warning('$parameterName was null');
+      final msg = '$parameterName was null';
+      _logger.warning(msg);
+      assert(false, msg);
     }
     // ignore: deprecated_member_use
     if (isDisposing) {
-      _logger.warning('$disposableTypeName.$methodName not allowed, object is disposing');
+      final msg = '$disposableTypeName.$methodName not allowed, object is disposing';
+      _logger.warning(msg);
+      assert(false, msg);
     }
     if (isDisposed) {
-      _logger.warning('$disposableTypeName.$methodName not allowed, object is already disposed');
+      var msg = '$disposableTypeName.$methodName not allowed, object is already disposed';
+      _logger.warning(msg);
+      assert(false, msg);
     }
   }
 
-  void _logOnInvalidCall2(
+  void _assertAndLogInvalidCall2(
       String methodName,
       String parameterName,
       String secondParameterName,
       dynamic parameterValue,
       dynamic secondParameterValue) {
     if (secondParameterValue == null) {
-      _logger.warning('$secondParameterName was null');
+      final msg = '$secondParameterName was null';
+      _logger.warning(msg);
+      assert(false, msg);
     }
-    _logOnInvalidCall(methodName, parameterName, parameterValue);
+    _assertAndLogOnInvalidCall(methodName, parameterName, parameterValue);
   }
 
   void _throwOnInvalidCall(
       String methodName, String parameterName, dynamic parameterValue) {
-    _logOnInvalidCall(methodName, parameterName, parameterValue);
+    _assertAndLogOnInvalidCall(methodName, parameterName, parameterValue);
     return;
     if (parameterValue == null) {
       throw ArgumentError.notNull(parameterName);
@@ -763,7 +771,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
       String secondParameterName,
       dynamic parameterValue,
       dynamic secondParameterValue) {
-    _logOnInvalidCall2(methodName, parameterName, secondParameterName, secondParameterValue);
+    _assertAndLogInvalidCall2(methodName, parameterName, secondParameterName, parameterValue, secondParameterValue);
     return;
     if (secondParameterValue == null) {
       throw ArgumentError.notNull(secondParameterName);

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -741,8 +741,8 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
 
   void _throwOnInvalidCall(
       String methodName, String parameterName, dynamic parameterValue) {
-    // _logOnInvalidCall(methodName, parameterName, parameterValue);
-    // return;
+    _logOnInvalidCall(methodName, parameterName, parameterValue);
+    return;
     if (parameterValue == null) {
       throw ArgumentError.notNull(parameterName);
     }
@@ -763,8 +763,8 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
       String secondParameterName,
       dynamic parameterValue,
       dynamic secondParameterValue) {
-    // _logOnInvalidCall2(methodName, parameterName, secondParameterName, secondParameterValue);
-    // return;
+    _logOnInvalidCall2(methodName, parameterName, secondParameterName, secondParameterValue);
+    return;
     if (secondParameterValue == null) {
       throw ArgumentError.notNull(secondParameterName);
     }

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -713,8 +713,36 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     }
   }
 
+  void _logOnInvalidCall(
+      String methodName, String parameterName, dynamic parameterValue) {
+    if (parameterValue == null) {
+      _logger.warning('$parameterName was null');
+    }
+    // ignore: deprecated_member_use
+    if (isDisposing) {
+      _logger.warning('$disposableTypeName.$methodName not allowed, object is disposing');
+    }
+    if (isDisposed) {
+      _logger.warning('$disposableTypeName.$methodName not allowed, object is already disposed');
+    }
+  }
+
+  void _logOnInvalidCall2(
+      String methodName,
+      String parameterName,
+      String secondParameterName,
+      dynamic parameterValue,
+      dynamic secondParameterValue) {
+    if (secondParameterValue == null) {
+      _logger.warning('$secondParameterName was null');
+    }
+    _logOnInvalidCall(methodName, parameterName, parameterValue);
+  }
+
   void _throwOnInvalidCall(
       String methodName, String parameterName, dynamic parameterValue) {
+    // _logOnInvalidCall(methodName, parameterName, parameterValue);
+    // return;
     if (parameterValue == null) {
       throw ArgumentError.notNull(parameterName);
     }
@@ -735,6 +763,8 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
       String secondParameterName,
       dynamic parameterValue,
       dynamic secondParameterValue) {
+    // _logOnInvalidCall2(methodName, parameterName, secondParameterName, secondParameterValue);
+    // return;
     if (secondParameterValue == null) {
       throw ArgumentError.notNull(secondParameterName);
     }

--- a/lib/src/common/disposable.dart
+++ b/lib/src/common/disposable.dart
@@ -378,7 +378,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   Future<T> awaitBeforeDispose<T>(Future<T> future) {
-    _throwOnInvalidCall('awaitBeforeDispose', 'future', future);
+    _handleInvalidCall('awaitBeforeDispose', 'future', future);
     _awaitableFutures.add(future);
     future.then((_) {
       if (!isOrWillBeDisposed) {
@@ -455,7 +455,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   Future<T> getManagedDelayedFuture<T>(Duration duration, T callback()) {
-    _throwOnInvalidCall2(
+    _handleInvalidCall2(
         'getManagedDelayedFuture', 'duration', 'callback', duration, callback);
     var completer = Completer<T>();
     var timer =
@@ -479,7 +479,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   ManagedDisposer getManagedDisposer(Disposer disposer) {
-    _throwOnInvalidCall('getManagedDisposer', 'disposer', disposer);
+    _handleInvalidCall('getManagedDisposer', 'disposer', disposer);
     _logManageMessage(disposer);
 
     var disposable = ManagedDisposer(disposer);
@@ -500,7 +500,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   Timer getManagedTimer(Duration duration, void callback()) {
-    _throwOnInvalidCall2(
+    _handleInvalidCall2(
         'getManagedTimer', 'duration', 'callback', duration, callback);
     var timer = _ObservableTimer(duration, callback);
     _addObservableTimerDisposable(timer);
@@ -510,7 +510,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   Timer getManagedPeriodicTimer(Duration duration, void callback(Timer timer)) {
-    _throwOnInvalidCall2(
+    _handleInvalidCall2(
         'getManagedPeriodicTimer', 'duration', 'callback', duration, callback);
     var timer = _ObservableTimer.periodic(duration, callback);
     _addObservableTimerDisposable(timer);
@@ -522,7 +522,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   StreamSubscription<T> listenToStream<T>(
       Stream<T> stream, void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
-    _throwOnInvalidCall2('listenToStream', 'stream', 'onData', stream, onData);
+    _handleInvalidCall2('listenToStream', 'stream', 'onData', stream, onData);
     var managedStreamSubscription = ManagedStreamSubscription(stream, onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
     _logManageMessage(managedStreamSubscription);
@@ -548,7 +548,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   Disposable manageAndReturnDisposable(Disposable disposable) {
-    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
+    _handleInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 
     return disposable;
@@ -557,7 +557,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   T manageAndReturnTypedDisposable<T extends Disposable>(T disposable) {
-    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
+    _handleInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 
     return disposable;
@@ -566,7 +566,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   Completer<T> manageCompleter<T>(Completer<T> completer) {
-    _throwOnInvalidCall('manageCompleter', 'completer', completer);
+    _handleInvalidCall('manageCompleter', 'completer', completer);
     _logManageMessage(completer);
 
     var disposable = ManagedDisposer(() async {
@@ -596,7 +596,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   void manageDisposable(Disposable disposable) {
-    _throwOnInvalidCall('manageDisposable', 'disposable', disposable);
+    _handleInvalidCall('manageDisposable', 'disposable', disposable);
     _logManageMessage(disposable);
 
     _internalDisposables.add(disposable);
@@ -613,7 +613,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   void manageDisposer(Disposer disposer) {
-    _throwOnInvalidCall('manageDisposer', 'disposer', disposer);
+    _handleInvalidCall('manageDisposer', 'disposer', disposer);
     _logManageMessage(disposer);
 
     _internalDisposables.add(ManagedDisposer(disposer));
@@ -622,7 +622,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   void manageStreamController(StreamController<dynamic> controller) {
-    _throwOnInvalidCall('manageStreamController', 'controller', controller);
+    _handleInvalidCall('manageStreamController', 'controller', controller);
     // If a single-subscription stream has a subscription and that
     // subscription is subsequently canceled, the `done` future will
     // complete, but there is no other way for us to tell that this
@@ -659,7 +659,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   void manageStreamSubscription(StreamSubscription<dynamic> subscription) {
-    _throwOnInvalidCall(
+    _handleInvalidCall(
         'manageStreamSubscription', 'subscription', subscription);
     _logManageMessage(subscription);
 
@@ -747,35 +747,17 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     _assertAndLogOnInvalidCall(methodName, parameterName, parameterValue);
   }
 
-  void _throwOnInvalidCall(
+  void _handleInvalidCall(
       String methodName, String parameterName, dynamic parameterValue) {
     _assertAndLogOnInvalidCall(methodName, parameterName, parameterValue);
-    return;
-    if (parameterValue == null) {
-      throw ArgumentError.notNull(parameterName);
-    }
-    // ignore: deprecated_member_use
-    if (isDisposing) {
-      throw StateError(
-          '$disposableTypeName.$methodName not allowed, object is disposing');
-    }
-    if (isDisposed) {
-      throw StateError(
-          '$disposableTypeName.$methodName not allowed, object is already disposed');
-    }
   }
 
-  void _throwOnInvalidCall2(
+  void _handleInvalidCall2(
       String methodName,
       String parameterName,
       String secondParameterName,
       dynamic parameterValue,
       dynamic secondParameterValue) {
     _assertAndLogInvalidCall2(methodName, parameterName, secondParameterName, parameterValue, secondParameterValue);
-    return;
-    if (secondParameterValue == null) {
-      throw ArgumentError.notNull(secondParameterName);
-    }
-    _throwOnInvalidCall(methodName, parameterName, parameterValue);
   }
 }


### PR DESCRIPTION
## Motivation
I'm not sure how many unhandled exceptions have arisen from Disposable throwing exceptions, but calling `manageDisposable(null)` for sure throws (e.g. [OI-1470] SEV2-HI for Workiva folks), as does managing something that's already disposed or disposing (see `_throwOnInvalidCall`). I really wonder if y'all would be on board with not throwing exceptions and just logging. I agree that consumers should check their inputs, but pragmatically, it's easy to mess that up and why should disposable care? 

## Changes
TBD

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
