### PR TITLE
Remove deprecated authors field from pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,6 @@
 name: w_common
 version: 1.20.4
 description: General utilities for Dart projects.
-author: Workiva Client Platform Team <team-clientplatform@workiva.com>
 homepage: https://www.github.com/Workiva/w_common
 
 environment:


### PR DESCRIPTION
This PR removes the author field from any `pubspec.yaml` files in this repo,
as the field was deprecated in Dart 2.7 and is no longer needed.

Removing this field will silence the warning that `pub publish` emits, which
has the added benefit of allowing us to use `pub publish --dry-run` as a
quality check during CI.

If you'd like to retain the author information, we recommend adding an
`AUTHORS.md` file in the repo or the package directory.

---

This PR was created automatically from a Sourcegraph batch change.
Please reach out to @evanweible-wf or #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/remove_pubspec_authors`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/remove_pubspec_authors)