### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   intl: ">=0.15.0 <0.18.0"
   js: ^0.6.3
   logging: ^1.0.1
-  meta: ^1.3.0
+  meta: ^1.2.2
   package_config: ^2.0.0
   path: ^1.8.0
   sass: '>=1.32.11 <2.0.0'
@@ -24,8 +24,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: '>=1.12.0 <3.0.0'
-  build_test: ^2.0.0
+  build_test: ">=0.10.9 <2.0.0"
   build_web_compilers: '>=2.16.5 <4.0.0'
   dependency_validator: ^3.0.0
   mockito: ^4.1.1
-  test: ^1.16.2
+  test: ^1.15.7


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)