### PR TITLE
Export LeakFlag class

### DIFF
--- a/lib/disposable.dart
+++ b/lib/disposable.dart
@@ -29,4 +29,4 @@ export 'package:w_common/src/common/disposable_manager.dart'
         DisposableManagerV7,
         ObjectDisposedException;
 export 'package:w_common/src/common/disposable.dart'
-    show Disposable, Disposer, ManagedDisposer;
+    show Disposable, Disposer, LeakFlag, ManagedDisposer;

--- a/lib/disposable_browser.dart
+++ b/lib/disposable_browser.dart
@@ -30,4 +30,4 @@ export 'package:w_common/src/common/disposable_manager.dart'
         ObjectDisposedException;
 export 'package:w_common/src/browser/disposable_browser.dart' show Disposable;
 export 'package:w_common/src/common/disposable.dart'
-    show Disposer, ManagedDisposer;
+    show Disposer, LeakFlag, ManagedDisposer;


### PR DESCRIPTION
## Motivation
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->
Currently consumers of disposable.dart are reaching into `src` to grab the `LeakFlag` class. This is not advisable.

## Changes
  <!-- What this PR changes to fix the problem. -->
Show `LeakFlag` class on export of disposable.dart 

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Client Platform team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-client-plat Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Passing CI

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Client Platform member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
