### PR TITLE
Adjust the dependency range of intl to allow 0.16.x

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   colorize: ^3.0.0
   file: ^6.0.0
   glob: ^2.0.0
-  intl: ">=0.15.0 <0.18.0"
+  intl: '>=0.15.8 <0.18.0'
   js: ^0.6.3
   logging: '>=0.11.3+2 <2.0.0'
   meta: ^1.3.0


### PR DESCRIPTION
# Description Adjust the dependency range of intl to allow 0.16.x versions. Also raise the minimum to 0.15.8, the version that wdesk resolves to today.
The 0.16.0 release of intl has been code reviewed, and no breakages are expected - only very minor typing updates were applied to some function parameters, and these parameters likely would already have the correct type in order for it to function properly now. We will double-check the app on 0.16.x once all packages allow it in their range.
Please merge once CI passes. For questions, reach out to #support-esg on Slack.
Thank you!

[_Created by Sourcegraph batch change `Workiva/upgrade_intl_allow_16`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/upgrade_intl_allow_16)