### PR TITLE
Raise analyzer minimum & unpin meta

### DIFF
--- a/w_common/pubspec.yaml
+++ b/w_common/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   intl: '>=0.15.8 <0.18.0'
   js: ^0.6.3
   logging: '>=0.11.3+2 <2.0.0'
-  meta: ^1.3.0
+  meta: ^1.6.0
 
 dev_dependencies:
   build_runner: '>=1.12.0 <3.0.0'

--- a/w_common_tools/pubspec.yaml
+++ b/w_common_tools/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   colorize: ^3.0.0
   file: ^6.0.0
   glob: ^2.0.0
-  meta: ^1.3.0
+  meta: ^1.6.0
   package_config: ^2.0.0
   path: ^1.8.0
   sass: ^1.32.11


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

This will require analyzer 1.7.2+ and now that we're past analyzer 1.7.1
we can unpin the meta dependency. (We had restricted it to <1.7.0 in many places)

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/analyzer1_unpin_meta`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/analyzer1_unpin_meta)