### PR TITLE
Raise minimums

### DIFF
--- a/w_common/pubspec.yaml
+++ b/w_common/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  intl: '>=0.17.0 <0.19.0'
+  intl: ^0.18.0
   js: ^0.6.3
   logging: ^1.0.0
   meta: ^1.3.0


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! More details at
https://wiki.atl.workiva.net/display/CP/Dependency+Upgrades

```
  # Raise minimums for package versions that we already resolve to
  pubspec_codemod raise-min w_intl 2.0.0 --recursive
  pubspec_codemod raise-min json_schema 5.0.0 --recursive
  pubspec_codemod raise-min intl 0.18.0 --recursive
  pubspec_codemod raise-min color 3.0.0 --recursive
  pubspec_codemod raise-min memoize 3.0.0 --recursive
```

A passing CI is sufficient QA (means dependencies resolve and tests run and pass).

For more info, reach out to Rob Becker in `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/raise_mins_5_31`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/raise_mins_5_31)