### PR TITLE
Update dev dependencies for analyzer 2

### DIFF
--- a/w_common_tools/pubspec.yaml
+++ b/w_common_tools/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   watcher: ^1.0.0
 
 dev_dependencies:
-  build_runner: '>=1.12.0 <3.0.0'
+  build_runner: ^2.0.0
   build_test: ^2.0.0
-  build_web_compilers: '>=2.16.5 <4.0.0'
+  build_web_compilers: ^3.0.0
   dependency_validator: ^3.0.0
   mockito: '>=5.0.0 <5.3.0' # pin to workaround https://github.com/dart-lang/mockito/issues/552
   test: ^1.16.2


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies! Now that we can resolve to analyzer 2
we can raise the minimums of many dependencies were ranged to support both 
analyzer 1 and 2.

```
  pubspec_codemod raise-min analyzer 2.0.0 --recursive
  pubspec_codemod raise-min dependency_validator 3.0.0 --recursive
  pubspec_codemod raise-min test_html_builder 3.0.0 --recursive
  pubspec_codemod raise-min dart_style 2.0.0 --recursive
  pubspec_codemod raise-min build_web_compilers 3.0.0 --recursive
  pubspec_codemod raise-min build_test 2.0.0 --recursive
  pubspec_codemod raise-min build_runner 2.0.0 --recursive
  pubspec_codemod raise-min w_common 3.0.0 --recursive
  pubspec_codemod raise-min w_common_tools 3.0.0 --recursive
  pubspec_codemod raise-min uuid 3.0.0 --recursive
  pubspec_codemod raise-min fluri 2.0.0 --recursive
  pubspec_codemod raise-min get_it 6.0.0 --recursive
  pubspec_codemod raise-min dart_dev 4.0.0 --recursive
```

A passing CI is sufficient QA (that means dependencies resolve and tests run and pass).

For question or concerns visit `#support-frontend-dx`

[_Created by Sourcegraph batch change `Workiva/update_dev_deps_analyzer2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/update_dev_deps_analyzer2)