### PR TITLE
Raise the meta dependency min to v1.16.0

### DIFF
--- a/w_common/pubspec.yaml
+++ b/w_common/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   intl: '>=0.17.0 <0.19.0'
   js: ^0.6.3
   logging: ^1.0.0
-  meta: ^1.3.0
+  meta: ^1.16.0
 
 dev_dependencies:
   build_runner: ^2.0.0


### PR DESCRIPTION
This PR raises the min version of meta to 1.16.0. Passing CI
should be sufficient for QA, so feel free to review and merge this once CI completes.

For more info, reach out to `#support-frontend-dx` on Slack.

[_Created by Sourcegraph batch change `Workiva/meta_raise_min_v1_16_0_really`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/meta_raise_min_v1_16_0_really)