### PR TITLE
FEDX-1991: allow a nullable to be managed

### DIFF
--- a/w_common/CHANGELOG.md
+++ b/w_common/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [3.3.0](https://github.com/Workiva/w_common/compare/3.2.0...3.3.0)
+- Allow a nullable to be managed via `Disposable.manageDisposable` and 
+`Disposable.manageAndReturnTypedDisposable`.
+
+## [3.2.0](https://github.com/Workiva/w_common/compare/3.1.0...3.2.0)
+
+- Adds JsonMap and JsonMapObject typedefs
+
 ## [3.1.0](https://github.com/Workiva/w_common/compare/3.0.0...3.1.0)
 
 - Adds JsonMap and JsonMapObject typedefs

--- a/w_common/CHANGELOG.md
+++ b/w_common/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 ## [3.1.0](https://github.com/Workiva/w_common/compare/3.0.0...3.1.0)
 
-- Adds JsonMap and JsonMapObject typedefs
 - Update SDK minimum to 2.19.0 to support the non-function
  typedef language feature.
 - Raised package versions to their first nullsafe version.

--- a/w_common/lib/src/browser/disposable_browser.dart
+++ b/w_common/lib/src/browser/disposable_browser.dart
@@ -243,8 +243,7 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
-  T manageAndReturnTypedDisposable<T extends disposable_common.Disposable>(
-          T disposable) =>
+  T? manageAndReturnTypedDisposable<T extends disposable_common.Disposable>(T? disposable) =>
       _disposable.manageAndReturnTypedDisposable(disposable);
 
   @override
@@ -252,7 +251,7 @@ class Disposable implements disposable_common.Disposable {
       _disposable.manageCompleter(completer);
 
   @override
-  void manageDisposable(disposable_common.Disposable disposable) =>
+  void manageDisposable(disposable_common.Disposable? disposable) =>
       _disposable.manageDisposable(disposable);
 
   @override

--- a/w_common/lib/src/browser/disposable_browser.dart
+++ b/w_common/lib/src/browser/disposable_browser.dart
@@ -243,7 +243,8 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
-  T? manageAndReturnTypedDisposable<T extends disposable_common.Disposable>(T? disposable) =>
+  T? manageAndReturnTypedDisposable<T extends disposable_common.Disposable>(
+          T? disposable) =>
       _disposable.manageAndReturnTypedDisposable(disposable);
 
   @override

--- a/w_common/lib/src/browser/disposable_browser.dart
+++ b/w_common/lib/src/browser/disposable_browser.dart
@@ -243,9 +243,10 @@ class Disposable implements disposable_common.Disposable {
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
   @override
-  T? manageAndReturnTypedDisposable<T extends disposable_common.Disposable>(
-          T? disposable) =>
-      _disposable.manageAndReturnTypedDisposable(disposable);
+  T manageAndReturnTypedDisposable<T extends disposable_common.Disposable?>(
+      T disposable) {
+    return _disposable.manageAndReturnTypedDisposable<T>(disposable);
+  }
 
   @override
   Completer<T> manageCompleter<T>(Completer<T> completer) =>

--- a/w_common/lib/src/common/disposable.dart
+++ b/w_common/lib/src/common/disposable.dart
@@ -515,7 +515,8 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   T? manageAndReturnTypedDisposable<T extends Disposable>(T? disposable) {
-    _throwOnInvalidDisposable('manageAndReturnDisposable', 'disposable', disposable);
+    _throwOnInvalidDisposable(
+        'manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 
     return disposable;
@@ -664,8 +665,9 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     }
   }
 
-  void _throwOnInvalidDisposable(String methodName, String parameterName, Disposable? parameterValue){
-if (_isDisposing) {
+  void _throwOnInvalidDisposable(
+      String methodName, String parameterName, Disposable? parameterValue) {
+    if (_isDisposing) {
       throw StateError(
           '$disposableTypeName.$methodName not allowed, object is disposing');
     }

--- a/w_common/lib/src/common/disposable.dart
+++ b/w_common/lib/src/common/disposable.dart
@@ -514,7 +514,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
 
   @mustCallSuper
   @override
-  T? manageAndReturnTypedDisposable<T extends Disposable>(T? disposable) {
+  T manageAndReturnTypedDisposable<T extends Disposable?>(T disposable) {
     _throwOnInvalidDisposable(
         'manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);

--- a/w_common/lib/src/common/disposable.dart
+++ b/w_common/lib/src/common/disposable.dart
@@ -514,8 +514,8 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
 
   @mustCallSuper
   @override
-  T manageAndReturnTypedDisposable<T extends Disposable>(T disposable) {
-    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
+  T? manageAndReturnTypedDisposable<T extends Disposable>(T? disposable) {
+    _throwOnInvalidDisposable('manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 
     return disposable;
@@ -552,12 +552,11 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     return completer;
   }
 
-  void manageDisposable(Disposable disposable) {
-    // ignore: unnecessary_null_comparison
+  void manageDisposable(Disposable? disposable) {
     if (disposable == null) {
       return;
     }
-    _throwOnInvalidCall('manageDisposable', 'disposable', disposable);
+    _throwOnInvalidDisposable('manageDisposable', 'disposable', disposable);
     _logManageMessage(disposable);
 
     _internalDisposables.add(disposable);
@@ -656,6 +655,17 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
       throw ArgumentError.notNull(parameterName);
     }
     if (_isDisposing) {
+      throw StateError(
+          '$disposableTypeName.$methodName not allowed, object is disposing');
+    }
+    if (isDisposed) {
+      throw StateError(
+          '$disposableTypeName.$methodName not allowed, object is already disposed');
+    }
+  }
+
+  void _throwOnInvalidDisposable(String methodName, String parameterName, Disposable? parameterValue){
+if (_isDisposing) {
       throw StateError(
           '$disposableTypeName.$methodName not allowed, object is disposing');
     }

--- a/w_common/lib/src/common/disposable.dart
+++ b/w_common/lib/src/common/disposable.dart
@@ -515,8 +515,11 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
   @mustCallSuper
   @override
   T manageAndReturnTypedDisposable<T extends Disposable?>(T disposable) {
-    _throwOnInvalidDisposable(
-        'manageAndReturnDisposable', 'disposable', disposable);
+    if (disposable == null) {
+      return disposable;
+    }
+
+    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
     manageDisposable(disposable);
 
     return disposable;
@@ -557,7 +560,7 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     if (disposable == null) {
       return;
     }
-    _throwOnInvalidDisposable('manageDisposable', 'disposable', disposable);
+    _throwOnInvalidCall('manageDisposable', 'disposable', disposable);
     _logManageMessage(disposable);
 
     _internalDisposables.add(disposable);
@@ -655,18 +658,6 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
     if (parameterValue == null) {
       throw ArgumentError.notNull(parameterName);
     }
-    if (_isDisposing) {
-      throw StateError(
-          '$disposableTypeName.$methodName not allowed, object is disposing');
-    }
-    if (isDisposed) {
-      throw StateError(
-          '$disposableTypeName.$methodName not allowed, object is already disposed');
-    }
-  }
-
-  void _throwOnInvalidDisposable(
-      String methodName, String parameterName, Disposable? parameterValue) {
     if (_isDisposing) {
       throw StateError(
           '$disposableTypeName.$methodName not allowed, object is disposing');

--- a/w_common/lib/src/common/disposable.dart
+++ b/w_common/lib/src/common/disposable.dart
@@ -519,7 +519,8 @@ class Disposable implements _Disposable, DisposableManagerV7, LeakFlagger {
       return disposable;
     }
 
-    _throwOnInvalidCall('manageAndReturnDisposable', 'disposable', disposable);
+    _throwOnInvalidCall(
+        'manageAndReturnTyped Disposable', 'disposable', disposable);
     manageDisposable(disposable);
 
     return disposable;

--- a/w_common/lib/src/common/disposable_manager.dart
+++ b/w_common/lib/src/common/disposable_manager.dart
@@ -47,7 +47,7 @@ abstract class DisposableManagerV7 {
   ///      }
   ///
   /// A null parameter will result in a null return value.
-  T? manageAndReturnTypedDisposable<T extends Disposable>(T? disposable);
+  T manageAndReturnTypedDisposable<T extends Disposable?>(T disposable);
 
   /// Automatically cancel a stream controller when this object is disposed.
   ///

--- a/w_common/lib/src/common/disposable_manager.dart
+++ b/w_common/lib/src/common/disposable_manager.dart
@@ -47,7 +47,7 @@ abstract class DisposableManagerV7 {
   ///      }
   ///
   /// A null parameter will result in a null return value.
-  T manageAndReturnTypedDisposable<T extends Disposable>(T disposable);
+  T? manageAndReturnTypedDisposable<T extends Disposable>(T? disposable);
 
   /// Automatically cancel a stream controller when this object is disposed.
   ///

--- a/w_common/test/unit/disposable_common.dart
+++ b/w_common/test/unit/disposable_common.dart
@@ -216,7 +216,8 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       StubDisposable? nullable;
       var returnValue;
       expect(() {
-        returnValue = disposable.manageAndReturnTypedDisposable(nullable);
+        returnValue = disposable
+            .manageAndReturnTypedDisposable<StubDisposable?>(nullable);
       }, returnsNormally);
       expect(returnValue, isNull);
     });

--- a/w_common/test/unit/disposable_common.dart
+++ b/w_common/test/unit/disposable_common.dart
@@ -214,7 +214,7 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
 
     testManageMethod(
         'manageAndReturnTypedDisposable',
-        (StubDisposable argument) =>
+        (StubDisposable? argument) =>
             disposable.manageAndReturnTypedDisposable(argument),
         disposableFactory());
   });

--- a/w_common/test/unit/disposable_common.dart
+++ b/w_common/test/unit/disposable_common.dart
@@ -212,6 +212,15 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
       expect(disposable.injected!.isDisposed, isFalse);
     });
 
+    test('should not throw if value is null', () async {
+      StubDisposable? nullable;
+      var returnValue;
+      expect(() {
+        returnValue = disposable.manageAndReturnTypedDisposable(nullable);
+      }, returnsNormally);
+      expect(returnValue, isNull);
+    });
+
     testManageMethod(
         'manageAndReturnTypedDisposable',
         (StubDisposable? argument) =>
@@ -815,6 +824,13 @@ void testCommonDisposable(Func<StubDisposable> disposableFactory) {
   });
 
   group('manageDisposable', () {
+    test('should not throw if value is null', () async {
+      StubDisposable? nullable;
+      expect(() {
+        disposable.manageDisposable(nullable);
+      }, returnsNormally);
+    });
+
     test('should dispose child when parent is disposed', () async {
       var childThing = disposableFactory();
       disposable.manageDisposable(childThing);


### PR DESCRIPTION
## Motivation

When migrating disposables to null safety, it would be helpful to be able to manage a **nullable** disposable. For example:
```
 LoggingDataService? logging;
...
void _cloneBaseDataServices(AppIntelligence other) {
manageDisposable(logging);
}
```
Alternatively,
```
 LoggingDataService? logging;
...
void _cloneBaseDataServices(AppIntelligence other) {
logging = manageAndReturnTypedDisposable(other.logging?.clone(_appName));
}
```

In fact, when we inspect the `manageDisposable` [implementation](https://github.com/Workiva/w_common/blob/master/w_common/lib/src/common/disposable.dart#L557 ), we see that we have already accommodated the incoming value being null, despite our nullable-typing suggesting it cannot be.  I believe this was an oversight.


Additionally, the [comment](https://github.com/Workiva/w_common/blob/master/w_common/lib/src/common/disposable_manager.dart#L49) on `manageAndReturnTypedDisposable` suggests that it was our intention to return a null if a null was passed in as the target:
```
/// A null parameter will result in a null return value.
T manageAndReturnTypedDisposable<T extends Disposable>(T disposable);
```

## Changes

- Adjusted `manageAndReturnTypedDisposable` to allow nullables
- Added `_throwOnInvalidDisposable` which will still perform the state verification but will not throw if the value is null. (This was done to accommodate `manageAndReturnTypedDisposable`)

#### Release Notes
  <!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->

## Review
_[See CONTRIBUTING.md][contributing-review-types] for more details on review types (+1 / QA +1 / +10) and code review process._

  <!-- If you're making a PR from outside of the Frontend Architecture team, then first off, thanks! :)

        For open-source contributors, tag @Workiva/app-frameworks and we'll take a look!

        For Workiva employees:

            *** Please refrain from tagging the whole team to prevent extraneous notifications. ***

            If you're not sure who from our team should review these changes, then leave this section
            blank for now and post a link to the PR in the #support-frontend-architecture Slack channel.

  -->

Please review: <!-- Tag people here or via GitHub's "Request Review" feature-->

### QA Checklist
- [ ] Tests were updated and provide good coverage of the changeset and other affected code
- [ ] Manual testing was performed if needed
    - [ ] Steps from PR author: 
        <!-- Call out any specific manual testing instructions here, or omit this section if not applicable -->
    - [ ] Anything falling under manual testing criteria [outlined in CONTRIBUTING.md][contributing-manual-testing]

## Merge Checklist
While we perform many automated checks before auto-merging, some manual checks are needed:
- [ ] A Frontend Architecture member has reviewed these changes
- [ ] There are no unaddressed comments _- this check can be automated if reviewers use the "Request Changes" feature_
- [ ] _For release PRs -_ Version metadata in Rosie comment is correct


[contributing-review-types]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#review-types
[contributing-manual-testing]: https://github.com/Workiva/w_common/blob/master/CONTRIBUTING.md#manual-testing-criteria
